### PR TITLE
Listen to localhost instead of all network interfaces

### DIFF
--- a/redis-session/src/main.rs
+++ b/redis-session/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
             ))
             // register simple route, handle all methods
             .resource("/", |r| r.f(index))
-    }).bind("0.0.0.0:8080")
+    }).bind("127.0.0.1:8080")
         .unwrap()
         .start();
 

--- a/template_askama/src/main.rs
+++ b/template_askama/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
     // start http server
     server::new(move || {
         App::new().resource("/", |r| r.method(http::Method::GET).with(index))
-    }).bind("0.0.0.0:8080")
+    }).bind("127.0.0.1:8080")
         .unwrap()
         .start();
 


### PR DESCRIPTION
When we listen on all network interfaces instead of localhost, Mac shows this pop window. Maybe listening on 0.0.0.0 was not intended?

<img width="454" alt="screen shot 2018-05-31 at 21 51 56" src="https://user-images.githubusercontent.com/222507/40805580-085f83b0-651f-11e8-927a-5a676f960816.png">
