### PR TITLE
Removed duplicate dependency in askama Cargo.toml

### DIFF
--- a/template_askama/Cargo.toml
+++ b/template_askama/Cargo.toml
@@ -9,6 +9,3 @@ env_logger = "0.5"
 actix = "0.5"
 actix-web = "^0.6"
 askama = "0.6"
-
-[build-dependencies]
-askama = "0.6"


### PR DESCRIPTION
It seems to me that the build dependency section is not required, since it is covered under dependencies. Or am I missing something?