### PR TITLE
Fix pinging so client doesn't get dropped automatically after 10 seconds

### DIFF
--- a/websocket-chat/src/main.rs
+++ b/websocket-chat/src/main.rs
@@ -113,6 +113,9 @@ impl StreamHandler<ws::Message, ws::ProtocolError> for WsChatSession {
                 self.hb = Instant::now();
                 ctx.pong(&msg);
             }
+            ws::Message::Pong(_) => {
+                self.hb = Instant::now();
+            }
             ws::Message::Text(text) => {
                 let m = text.trim();
                 // we check for /sss type of messages
@@ -183,7 +186,6 @@ impl StreamHandler<ws::Message, ws::ProtocolError> for WsChatSession {
             ws::Message::Close(_) => {
                 ctx.stop();
             },
-            _ => (),
         }
     }
 }

--- a/websocket-tcp-chat/src/main.rs
+++ b/websocket-tcp-chat/src/main.rs
@@ -119,6 +119,9 @@ impl StreamHandler<ws::Message, ws::ProtocolError> for WsChatSession {
                 self.hb = Instant::now();
                 ctx.pong(&msg);
             }
+            ws::Message::Pong(_) => {
+                self.hb = Instant::now();
+            }
             ws::Message::Text(text) => {
                 let m = text.trim();
                 // we check for /sss type of messages
@@ -189,7 +192,6 @@ impl StreamHandler<ws::Message, ws::ProtocolError> for WsChatSession {
             ws::Message::Close(_) => {
                 ctx.stop();
             },
-            _ => (),
         }
     }
 }

--- a/websocket/src/main.rs
+++ b/websocket/src/main.rs
@@ -52,12 +52,14 @@ impl StreamHandler<ws::Message, ws::ProtocolError> for MyWebSocket {
                 self.hb = Instant::now();
                 ctx.pong(&msg);
             }
+            ws::Message::Pong(_) => {
+                self.hb = Instant::now();
+            }
             ws::Message::Text(text) => ctx.text(text),
             ws::Message::Binary(bin) => ctx.binary(bin),
             ws::Message::Close(_) => {
                 ctx.stop();
             }
-            _ => (),
         }
     }
 }


### PR DESCRIPTION
The server would ping the client on a regular interval but never actually handled the pong, so the client disconnected after 10 seconds regardless.