### PR TITLE
replace deprecated feature "alpn" with "ssl"

### DIFF
--- a/tls/Cargo.toml
+++ b/tls/Cargo.toml
@@ -12,4 +12,4 @@ path = "src/main.rs"
 env_logger = "0.5"
 openssl = { version="0.10" }
 actix = "0.7"
-actix-web = { version = "0.7", features=["alpn"] }
+actix-web = { version = "0.7", features=["ssl"] }


### PR DESCRIPTION
In actix-web's Cargo.toml, feature "alpn" is marked as deprecated,
with the suggestion to use "ssl", instead.