### PR TITLE
Add template yarte

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
   "static_index",
   "template_askama",
   "template_tera",
+  "template_yarte",
   "tls",
   "rustls",
   "unix-socket",

--- a/template_yarte/Cargo.toml
+++ b/template_yarte/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "example"
+version = "0.0.1"
+authors = ["Rust-iendo Barcelona <riendocontributions@gmail.com>"]
+publish = false
+edition = "2018"
+
+workspace = ".."
+
+[dependencies]
+env_logger = "0.5"
+
+yarte = { version = "0.1", features=["with-actix-web"]  }
+
+actix = "0.7"
+actix-web = "0.7"
+
+[build-dependencies]
+yarte = { version = "0.1", features=["with-actix-web"]  }

--- a/template_yarte/README.md
+++ b/template_yarte/README.md
@@ -1,0 +1,11 @@
+# yarte
+
+Example of composition with partials and `with-actix-web` feature
+
+See the generated code on stdout when run at debug
+```bash
+cargo run
+```
+> open `localhost:8080`
+
+More at [mdbook](https://yarte.netlify.com/) and [repository](https://gitlab.com/r-iendo/yarte)

--- a/template_yarte/build.rs
+++ b/template_yarte/build.rs
@@ -1,0 +1,5 @@
+use yarte::recompile;
+
+fn main() {
+    recompile::when_changed();
+}

--- a/template_yarte/src/lib.rs
+++ b/template_yarte/src/lib.rs
@@ -1,0 +1,14 @@
+use actix_web::{Query, Responder};
+use yarte::Template;
+
+use std::collections::HashMap;
+
+#[derive(Template)]
+#[template(path = "index.hbs")]
+struct IndexTemplate {
+    query: Query<HashMap<String, String>>,
+}
+
+pub fn index(query: Query<HashMap<String, String>>) -> impl Responder {
+    IndexTemplate { query }
+}

--- a/template_yarte/src/main.rs
+++ b/template_yarte/src/main.rs
@@ -1,0 +1,19 @@
+use actix_web::{http, server, App};
+
+#[path = "lib.rs"]
+mod template;
+
+fn main() {
+    let sys = actix::System::new("example-yarte");
+
+    // start http server
+    server::new(move || {
+        App::new().resource("/", |r| r.method(http::Method::GET).with(template::index))
+    })
+    .bind("127.0.0.1:8080")
+    .unwrap()
+    .start();
+
+    println!("Started http server: 127.0.0.1:8080");
+    let _ = sys.run();
+}

--- a/template_yarte/templates/deep/more/deep/welcome.hbs
+++ b/template_yarte/templates/deep/more/deep/welcome.hbs
@@ -1,0 +1,1 @@
+<{{ tag }}>Welcome!</{{ tag }}>

--- a/template_yarte/templates/index.hbs
+++ b/template_yarte/templates/index.hbs
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <title>Actix web</title>
+</head>
+<body>
+{{~#if let Some(name) = query.get("name") ~}}
+    <h1>Hi, {{ name }}!</h1>
+    {{~> alias/welcome tag='p' ~}}
+{{~ else ~}}
+    {{~> alias/welcome tag="h1" ~}}
+    <p>
+    <h3>What is your name?</h3>
+    <form>
+        <input type="text" name="name"/><br/>
+        <p><input type="submit"></p>
+    </form>
+    </p>
+{{~/if~}}
+</body>
+</html>

--- a/template_yarte/yarte.toml
+++ b/template_yarte/yarte.toml
@@ -1,0 +1,14 @@
+# root dir of templates
+[main]
+dir = "templates"
+debug = "code"
+
+# Alias for partials. In call, change the start of partial path with one of this, if exist.
+[partials]
+alias = "./deep/more/deep"
+
+[debug]
+# prettyprint themes, put anything for options
+theme = "zenburn"
+number_line = true
+grid = true


### PR DESCRIPTION
I would like to emphasize the two functionalities: 
 - Partials if you throw `cargo run` you will see the result by stdout. 
 - Hierarchical name resolution which allows to resolve and create names in different scopes with the minimum code. Resolve within any context, including tuples with `_n` for the n-th element.

The result is modular templates by composition without cost.