### PR TITLE
Update example to most recent askama release

### DIFF
--- a/template_askama/Cargo.toml
+++ b/template_askama/Cargo.toml
@@ -6,10 +6,10 @@ workspace = "../"
 
 [dependencies]
 env_logger = "0.5"
-askama = "0.6"
+askama = { version = "0.8", features = ["with-actix-web"] }
 
 actix = "0.7"
 actix-web = "0.7"
 
 [build-dependencies]
-askama = "0.6"
+askama = "0.8"

--- a/template_askama/src/main.rs
+++ b/template_askama/src/main.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 
 use actix_web::{http, server, App, HttpResponse, Query, Result};
 use askama::Template;
+use askama::actix_web::TemplateIntoResponse;
 
 #[derive(Template)]
 #[template(path = "user.html")]
@@ -20,16 +21,14 @@ struct UserTemplate<'a> {
 struct Index;
 
 fn index(query: Query<HashMap<String, String>>) -> Result<HttpResponse> {
-    let s = if let Some(name) = query.get("name") {
+    if let Some(name) = query.get("name") {
         UserTemplate {
             name: name,
             text: "Welcome!",
-        }.render()
-            .unwrap()
+        }.into_response()
     } else {
-        Index.render().unwrap()
-    };
-    Ok(HttpResponse::Ok().content_type("text/html").body(s))
+        Index.into_response()
+    }
 }
 
 fn main() {


### PR DESCRIPTION
This simplifies the code enormously as explicit `render` calls
are no longer needed with askama's actix-web integration.

Discovery on how to enable crate features can be a bit tricky for new users so this could be a helpful resource for new askama users.