### PR TITLE
Fixes parentheses in template_askama main.rs

### DIFF
--- a/template_askama/src/main.rs
+++ b/template_askama/src/main.rs
@@ -31,7 +31,7 @@ fn index(query: web::Query<HashMap<String, String>>) -> Result<HttpResponse> {
 fn main() -> std::io::Result<()> {
     // start http server
     HttpServer::new(move || {
-        App::new().service(web::resource("/").route(web::get()).to(index))
+        App::new().service(web::resource("/").route(web::get().to(index)))
     })
     .bind("127.0.0.1:8080")?
     .run()


### PR DESCRIPTION
Switches the position of a rogue parenthesis so that the index function is actually called.