### PR TITLE
clarify use of sleep in async_db

### DIFF
--- a/async_db/src/db.rs
+++ b/async_db/src/db.rs
@@ -58,7 +58,7 @@ fn get_hottest_years(conn: Connection) -> Result<Vec<WeatherAgg>, Error> {
                 .collect::<Vec<WeatherAgg>>())
         })?;
 
-    sleep(Duration::from_secs(2));
+    sleep(Duration::from_secs(2)); //see comments at top of main.rs
 
     Ok(annuals)
 }
@@ -84,7 +84,7 @@ fn get_coldest_years(conn: Connection) -> Result<Vec<WeatherAgg>, Error> {
                 .collect::<Vec<WeatherAgg>>())
         })?;
 
-    sleep(Duration::from_secs(2));
+    sleep(Duration::from_secs(2)); //see comments at top of main.rs
 
     Ok(annuals)
 }
@@ -111,7 +111,7 @@ fn get_hottest_months(conn: Connection) -> Result<Vec<WeatherAgg>, Error> {
                 .collect::<Vec<WeatherAgg>>())
         })?;
 
-    sleep(Duration::from_secs(2));
+    sleep(Duration::from_secs(2)); //see comments at top of main.rs
     Ok(annuals)
 }
 
@@ -137,6 +137,6 @@ fn get_coldest_months(conn: Connection) -> Result<Vec<WeatherAgg>, Error> {
                 .collect::<Vec<WeatherAgg>>())
         })?;
 
-    sleep(Duration::from_secs(2));
+    sleep(Duration::from_secs(2)); //see comments at top of main.rs
     Ok(annuals)
 }

--- a/async_db/src/main.rs
+++ b/async_db/src/main.rs
@@ -8,6 +8,8 @@ This project illustrates two examples:
     2. An asynchronous handler that executes 4 queries in *parallel*,
        collecting the results and returning them as a single serialized json object
 
+    Note: The use of sleep(Duration::from_secs(2)); in db.rs is to make performance 
+          improvement with parallelism more obvious.
  */
 use std::io;
 


### PR DESCRIPTION
Clarified the use of `sleep(Duration::from_secs(2));` by extending the comments at the top of the main.rs and commenting each use with `//see comments at top of main.rs`