### PR TITLE
fix streaming issue in http-full-proxy example

### DIFF
--- a/http-full-proxy/src/main.rs
+++ b/http-full-proxy/src/main.rs
@@ -32,7 +32,7 @@ fn forward(
             {
                 client_resp.header(header_name.clone(), header_value.clone());
             }
-            client_resp.streaming(res)
+            HttpResponse::Ok().streaming(res)
         })
 }
 


### PR DESCRIPTION
This change should fix empty (error) response of http-full-proxy example.

Tested on sample example `./http-full-proxy 127.0.0.1 8080 127.0.0.1 80` and it worked as expected, content from 80 is shown.