### PR TITLE
Revert "fix streaming issue in http-full-proxy example"

### DIFF
--- a/http-full-proxy/src/main.rs
+++ b/http-full-proxy/src/main.rs
@@ -32,7 +32,7 @@ fn forward(
             {
                 client_resp.header(header_name.clone(), header_value.clone());
             }
-            HttpResponse::Ok().streaming(res)
+            client_resp.streaming(res)
         })
 }
 


### PR DESCRIPTION
Reverts actix/examples#120

Please revert this change, I was wrong. It works, but I've tried it in combination with [Miniserve](https://github.com/svenstaro/miniserve) and there is `content-encoding: br` header (`br` means Brotli).

There is still issue in case `content-encoding` is `br`, but in other cases proxy works just fine.

(btw. my change was totally wrong, sorry)