### PR TITLE
Fix bug in database script

### DIFF
--- a/async_db/db/setup_db.sh
+++ b/async_db/db/setup_db.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
-sqlite3 weather.db < db.sql
-sqlite3 -csv weather.db ".import nyc_centralpark_weather.csv nyc_weather"
+cd $(dirname "$0")
+sqlite3 ../weather.db < db.sql
+sqlite3 -csv ../weather.db ".import nyc_centralpark_weather.csv nyc_weather"


### PR DESCRIPTION
Fix error that occurs if script is used like in the async_db readme.

Error before this change:
``` bash
$ LANG=C bash db/setup_db.sh
db/setup_db.sh: line 2: db.sql: No such file or directory
Error: cannot open "nyc_centralpark_weather.csv
```