### PR TITLE
Fixes trivial typos.

### DIFF
--- a/middleware/README.md
+++ b/middleware/README.md
@@ -1,7 +1,7 @@
 ## Middleware example
 
 ```bash
-cd form
+cd middleware
 cargo run
 # Started http server: 127.0.0.1:8080
 ```

--- a/middleware/src/simple.rs
+++ b/middleware/src/simple.rs
@@ -3,10 +3,10 @@ use actix_web::{dev::ServiceRequest, dev::ServiceResponse, Error};
 use futures::future::{ok, FutureResult};
 use futures::{Future, Poll};
 
-// There are two step in middleware processing.
-// 1. Middleware initialization, middleware factory get called with
+// There are two steps in middleware processing.
+// 1. Middleware initialization, middleware factory gets called with
 //    next service in chain as parameter.
-// 2. Middleware's call method get called with normal request.
+// 2. Middleware's call method gets called with normal request.
 pub struct SayHi;
 
 // Middleware factory is `Transform` trait from actix-service crate


### PR DESCRIPTION
I'm looking at how to do middleware in 1.0 and noticed a couple of typos. GIt log suggests you accept trivial fixes like this, so I fixed them, even though they're inconsequential.