### PR TITLE
add unused validation to async_ex1 example

### DIFF
--- a/async_ex1/src/main.rs
+++ b/async_ex1/src/main.rs
@@ -22,8 +22,8 @@ use std::io;
 
 use actix_web::{
     client::Client,
-    web::{self, BytesMut},
     error::ErrorBadRequest,
+    web::{self, BytesMut},
     App, Error, HttpResponse, HttpServer,
 };
 use futures::{Future, Stream};


### PR DESCRIPTION
Pretty much a mirror of #83, the validation was lost in the examples migration from 0.7 -> 1.0.