### PR TITLE
Read SQLite path from .env and fix DATABASE_URL

### DIFF
--- a/diesel/.env
+++ b/diesel/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=file:test.db
+DATABASE_URL=test.db

--- a/diesel/README.md
+++ b/diesel/README.md
@@ -9,7 +9,7 @@ Diesel's `Getting Started` guide using SQLite for Actix web
 ```bash
 cargo install diesel_cli --no-default-features --features sqlite
 cd examples/diesel
-echo "DATABASE_URL=file:test.db" > .env
+echo "DATABASE_URL=test.db" > .env
 diesel migration run
 ```
 

--- a/diesel/src/main.rs
+++ b/diesel/src/main.rs
@@ -13,6 +13,7 @@ use actix_web::{error, middleware, web, App, Error, HttpResponse, HttpServer};
 use bytes::BytesMut;
 use diesel::prelude::*;
 use diesel::r2d2::{self, ConnectionManager};
+use dotenv;
 use futures::future::{err, Either};
 use futures::{Future, Stream};
 
@@ -120,8 +121,10 @@ fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "actix_web=info");
     env_logger::init();
 
-    // Start 3 db executor actors
-    let manager = ConnectionManager::<SqliteConnection>::new("test.db");
+    dotenv::dotenv().ok();
+
+    let connspec = std::env::var("DATABASE_URL").expect("DATABASE_URL");
+    let manager = ConnectionManager::<SqliteConnection>::new(connspec);
     let pool = r2d2::Pool::builder()
         .build(manager)
         .expect("Failed to create pool.");


### PR DESCRIPTION
`diesel migration run` created a file named `file:test.db` and the application an empty `test.db`.