### PR TITLE
Do not decompress proxied responses

### DIFF
--- a/http-full-proxy/src/main.rs
+++ b/http-full-proxy/src/main.rs
@@ -15,7 +15,7 @@ fn forward(
     new_url.set_path(req.uri().path());
     new_url.set_query(req.uri().query());
 
-    let forwarded_req = client.request_from(new_url.as_str(), req.head());
+    let forwarded_req = client.request_from(new_url.as_str(), req.head()).no_decompress();
     let forwarded_req = if let Some(addr) = req.head().peer_addr {
         forwarded_req.header("x-forwarded-for", format!("{}", addr.ip()))
     } else {


### PR DESCRIPTION
If you decompress a proxied response that was encoded, the `content-encoding` header will be passed through but a plaintext body will be returned.