### PR TITLE
Ignore multipart example's png

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Cargo.lock
 .idea/**
 
 .history/
+
+# For multipart example
+upload.png


### PR DESCRIPTION
Ignore `upload.png` generated in multipart example