### PR TITLE
Fix favicon link on basics

### DIFF
--- a/basics/static/404.html
+++ b/basics/static/404.html
@@ -1,7 +1,14 @@
-<!DOCTYPE html><html><head><title>actix - basics</title>
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" /></head>
-  <body>
-    <a href="/static/welcome.html">back to home</a>
-    <h1>404</h1>
-  </body>
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>actix - basics</title>
+  <link rel="shortcut icon" type="image/x-icon" href="/favicon" />
+</head>
+
+<body>
+  <a href="/static/welcome.html">back to home</a>
+  <h1>404</h1>
+</body>
+
 </html>

--- a/basics/static/welcome.html
+++ b/basics/static/welcome.html
@@ -1,6 +1,13 @@
-<!DOCTYPE html><html><head><title>actix - basics</title>
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon" /></head>
-  <body>
-    <h1>Welcome <img width="30px" height="30px" src="/static/actixLogo.png" /></h1>
-  </body>
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>actix - basics</title>
+  <link rel="shortcut icon" type="image/x-icon" href="/favicon" />
+</head>
+
+<body>
+  <h1>Welcome <img width="30px" height="30px" src="/static/actixLogo.png" /></h1>
+</body>
+
 </html>


### PR DESCRIPTION
Replaces `href="/favicon.ico"` with `href="/favicon"` (and formats styles)