### PR TITLE
Always send body whole and don't use transfer encoding

### DIFF
--- a/http-proxy/src/main.rs
+++ b/http-proxy/src/main.rs
@@ -1,6 +1,7 @@
 use actix_web::client::Client;
 use actix_web::{middleware, web, App, Error, HttpRequest, HttpResponse, HttpServer};
 use clap::{value_t, Arg};
+use futures::stream::Stream;
 use futures::Future;
 use std::net::ToSocketAddrs;
 use url::Url;
@@ -15,6 +16,8 @@ fn forward(
     new_url.set_path(req.uri().path());
     new_url.set_query(req.uri().query());
 
+    // TODO: This forwarded implementation is incomplete as it only handles the inofficial
+    // X-Forwarded-For header but not the official Forwarded one.
     let forwarded_req = client
         .request_from(new_url.as_str(), req.head())
         .no_decompress();
@@ -27,19 +30,22 @@ fn forward(
     forwarded_req
         .send_body(body)
         .map_err(Error::from)
-        .map(|res| {
+        .map(|mut res| {
             let mut client_resp = HttpResponse::build(res.status());
             // Remove `Connection` as per
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection#Directives
-            for (header_name, header_value) in res
-                .headers()
-                .iter()
-                .filter(|(h, _)| *h != "connection")
+            for (header_name, header_value) in
+                res.headers().iter().filter(|(h, _)| *h != "connection")
             {
                 client_resp.header(header_name.clone(), header_value.clone());
             }
-            client_resp.streaming(res)
+            res.body()
+                .into_stream()
+                .concat2()
+                .map(move |b| client_resp.body(b))
+                .map_err(|e| e.into())
         })
+        .flatten()
 }
 
 fn main() -> std::io::Result<()> {


### PR DESCRIPTION
Without doing this, body size would be unknown at the time of sending, causing awc to use transfer encoding which is probably unexpected in most cases.
This change makes behavior more obvious.