### PR TITLE
Fix form example's test

### DIFF
--- a/form/src/main.rs
+++ b/form/src/main.rs
@@ -141,13 +141,14 @@ mod tests {
             .data(AppState {
                 foo: "bar".to_string(),
             })
-            .to_http_request()
-            .get_app_data()
+            .to_http_request();
+        let data = state
+            .app_data::<actix_web::web::Data<AppState>>()
             .unwrap();
         let params = Form(MyParams {
             name: "John".to_string(),
         });
-        let resp = handle_post_2(state, params).await;
+        let resp = handle_post_2(data.clone(), params).await;
 
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(

--- a/template_handlebars/src/README.md
+++ b/template_handlebars/src/README.md
@@ -4,4 +4,4 @@ This is an example of how to use Actix Web with the [Handlebars templating langu
 
 - http://localhost:8080
 - http://localhost:8080/Emma/documents
-- http://localhost:8080/Bob/passwordds
+- http://localhost:8080/Bob/passwords


### PR DESCRIPTION
The current form example can't be tested since `get_app_data()` has been removed.
Also fixes a typo on README of template_handlebars.