### PR TITLE
Fix logging in basics example

### DIFF
--- a/basics/src/main.rs
+++ b/basics/src/main.rs
@@ -66,7 +66,7 @@ async fn with_param(req: HttpRequest, path: web::Path<(String,)>) -> HttpRespons
 
 #[actix_rt::main]
 async fn main() -> io::Result<()> {
-    env::set_var("RUST_LOG", "actix_web=debug;actix_server=info");
+    env::set_var("RUST_LOG", "actix_web=debug,actix_server=info");
     env_logger::init();
 
     HttpServer::new(|| {


### PR DESCRIPTION
Basics example had a semicolon instead of a comma, causing logging not to work properly.