### PR TITLE
Use async-std in multipart example and treat all errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
    "juniper",
    "middleware",
    "multipart",
+   "multipart-async-std",
    "openssl",
 #   "protobuf",
    "r2d2",

--- a/multipart-async-std/.gitignore
+++ b/multipart-async-std/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+/tmp

--- a/multipart-async-std/Cargo.toml
+++ b/multipart-async-std/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "multipart-async-std-example"
+version = "0.3.0"
+authors = ["Bevan Hunt <bevan@bevanhunt.com>"]
+edition = "2018"
+license = "MIT"
+description = "Simple file uploader in Actix Web with Async/Await"
+keywords = ["actix", "actix-web", "multipart"]
+repository = "https://github.com/actix/examples"
+readme = "README.md"
+
+[dependencies]
+futures = "0.3.1"
+actix-multipart = "0.2.0"
+actix-web = "2.0.0"
+actix-rt = "1.0.0"
+async-std = "1.4.0"

--- a/multipart-async-std/LICENSE
+++ b/multipart-async-std/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [2019] [Bevan Hunt]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/multipart-async-std/README.md
+++ b/multipart-async-std/README.md
@@ -1,0 +1,11 @@
+# Actix Web File Upload with Async/Await
+
+### Run
+
+``` open web browser to localhost:3000 and upload file(s) ```
+
+### Result
+
+``` file(s) will show up in ./tmp in the same directory as the running process ```
+
+Note: this is a naive implementation and will panic on any error

--- a/multipart-async-std/src/main.rs
+++ b/multipart-async-std/src/main.rs
@@ -1,0 +1,59 @@
+use actix_multipart::Multipart;
+use actix_web::{middleware, web, App, Error, HttpResponse, HttpServer};
+use async_std::prelude::*;
+use futures::StreamExt;
+
+async fn save_file(mut payload: Multipart) -> Result<HttpResponse, Error> {
+    // iterate over multipart stream
+    while let Some(item) = payload.next().await {
+        let mut field = item?;
+        let content_type = field
+            .content_disposition()
+            .ok_or_else(|| actix_web::error::ParseError::Incomplete)?;
+        let filename = content_type
+            .get_filename()
+            .ok_or_else(|| actix_web::error::ParseError::Incomplete)?;
+        let filepath = format!("./tmp/{}", filename);
+        let mut f = async_std::fs::File::create(filepath).await?;
+
+        // Field in turn is stream of *Bytes* object
+        while let Some(chunk) = field.next().await {
+            let data = chunk.unwrap();
+            f.write_all(&data).await?;
+        }
+    }
+    Ok(HttpResponse::Ok().into())
+}
+
+fn index() -> HttpResponse {
+    let html = r#"<html>
+        <head><title>Upload Test</title></head>
+        <body>
+            <form target="/" method="post" enctype="multipart/form-data">
+                <input type="file" multiple name="file"/>
+                <input type="submit" value="Submit"></button>
+            </form>
+        </body>
+    </html>"#;
+
+    HttpResponse::Ok().body(html)
+}
+
+#[actix_rt::main]
+async fn main() -> std::io::Result<()> {
+    std::env::set_var("RUST_LOG", "actix_server=info,actix_web=info");
+    async_std::fs::create_dir_all("./tmp").await?;
+
+    let ip = "0.0.0.0:3000";
+
+    HttpServer::new(|| {
+        App::new().wrap(middleware::Logger::default()).service(
+            web::resource("/")
+                .route(web::get().to(index))
+                .route(web::post().to(save_file)),
+        )
+    })
+    .bind(ip)?
+    .run()
+    .await
+}


### PR DESCRIPTION
# Summary

In this PR I use `async_std` instead of blocking. Moreover, I treat all errors. I hope this makes the code more streamlined.