### PR TITLE
New example: Return JSON decode errors to a client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
    "hello-world",
    "http-proxy",
    "json",
+   "json_decode_error",
    "json_error",
    "jsonrpc",
    "juniper",

--- a/json_decode_error/Cargo.toml
+++ b/json_decode_error/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "json_decode_error"
+version = "0.1.0"
+authors = ["Stig Johan Berggren <stigjb@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+actix-web = "2.0.0"
+actix-rt = "1.0.0"
+serde = "1.0.104"

--- a/json_decode_error/README.md
+++ b/json_decode_error/README.md
@@ -33,7 +33,7 @@ ellipsis `...`.
 - Missing `Content-Type` header
 
   ```shell
-  $ curl 127.0.0.1:8088 -id '{"name": "Bob"}'
+  $ curl -i 127.0.0.1:8088 -d '{"name": "Bob"}'
   HTTP/1.1 415 Unsupported Media Type
   ...
 

--- a/json_decode_error/README.md
+++ b/json_decode_error/README.md
@@ -1,0 +1,65 @@
+# JSON decode errors
+
+This example demonstrates how to return useful error messages to the client
+when the server receives a request with invalid JSON, or which cannot be
+deserialized to the expected model. By configuring an `error_handler` on the
+route, we set response code to `422 Unprocessable Entity`, and return the
+string representation of the error.
+
+## Usage
+
+```shell
+cd examples/json_decode_error
+cargo run
+# Started HTTP server: 127.0.0.1:8088
+```
+
+## Examples
+
+The examples use `curl -i` in order to show the status line with the response
+code. The response headers have been omitted for brevity, and replaced with an
+ellipsis `...`.
+
+- A well-formed request
+
+  ```shell
+  $ curl -i 127.0.0.1:8088 -H 'Content-Type: application/json' -d '{"name": "Alice"}'
+  HTTP/1.1 200 OK
+  ...
+
+  Hello Alice! 
+  ```
+
+- Missing `Content-Type` header
+
+  ```shell
+  $ curl 127.0.0.1:8088 -id '{"name": "Bob"}'
+  HTTP/1.1 422 Unprocessable Entity
+  ...
+
+  Content type error
+  ```
+
+- Malformed JSON
+
+  ```shell
+  $ curl -i 127.0.0.1:8088 -H 'Content-Type: application/json' -d '{"name": "Eve}'
+  HTTP/1.1 422 Unprocessable Entity
+  ...
+
+  Json deserialize error: EOF while parsing a string at line 1 column 14
+  ```
+
+- JSON value of wrong type
+
+  ```shell
+  $ curl -i 127.0.0.1:8088 -H 'Content-Type: application/json' -d '{"name": 350}'
+  HTTP/1.1 422 Unprocessable Entity
+  ...
+
+  Json deserialize error: invalid type: integer `350`, expected a string at line 1 column 12
+  ```
+
+## More documentation
+
+[`actix_web::web::JsonConfig`](https://docs.rs/actix-web/latest/actix_web/web/struct.JsonConfig.html)

--- a/json_decode_error/README.md
+++ b/json_decode_error/README.md
@@ -60,6 +60,16 @@ ellipsis `...`.
   Json deserialize error: invalid type: integer `350`, expected a string at line 1 column 12
   ```
 
+- Wrong JSON key
+
+  ```shell
+  $ curl -i 127.0.0.1:8088 -H 'Content-Type: application/json' -d '{"namn": "John"}'
+  HTTP/1.1 422 Unprocessable Entity
+  ...
+
+  Json deserialize error: missing field `name` at line 1 column 16
+  ```
+
 ## More documentation
 
 [`actix_web::web::JsonConfig`](https://docs.rs/actix-web/latest/actix_web/web/struct.JsonConfig.html)

--- a/json_decode_error/README.md
+++ b/json_decode_error/README.md
@@ -3,8 +3,8 @@
 This example demonstrates how to return useful error messages to the client
 when the server receives a request with invalid JSON, or which cannot be
 deserialized to the expected model. By configuring an `error_handler` on the
-route, we set response code to `422 Unprocessable Entity`, and return the
-string representation of the error.
+route, we can set appropriate response codes and return the string
+representation of the error.
 
 ## Usage
 
@@ -34,7 +34,7 @@ ellipsis `...`.
 
   ```shell
   $ curl 127.0.0.1:8088 -id '{"name": "Bob"}'
-  HTTP/1.1 422 Unprocessable Entity
+  HTTP/1.1 415 Unsupported Media Type
   ...
 
   Content type error
@@ -44,7 +44,7 @@ ellipsis `...`.
 
   ```shell
   $ curl -i 127.0.0.1:8088 -H 'Content-Type: application/json' -d '{"name": "Eve}'
-  HTTP/1.1 422 Unprocessable Entity
+  HTTP/1.1 400 Bad Request
   ...
 
   Json deserialize error: EOF while parsing a string at line 1 column 14

--- a/json_decode_error/src/main.rs
+++ b/json_decode_error/src/main.rs
@@ -15,8 +15,11 @@ async fn greet(name: web::Json<Info>) -> impl Responder {
 
 fn json_error_handler(err: error::JsonPayloadError, _req: &HttpRequest) -> error::Error {
     let detail = format!("{}", err);
-    error::InternalError::from_response(err, HttpResponse::UnprocessableEntity().body(detail))
-        .into()
+    error::InternalError::from_response(
+        err,
+        HttpResponse::UnprocessableEntity().body(detail),
+    )
+    .into()
 }
 
 #[actix_rt::main]

--- a/json_decode_error/src/main.rs
+++ b/json_decode_error/src/main.rs
@@ -14,12 +14,19 @@ async fn greet(name: web::Json<Info>) -> impl Responder {
 }
 
 fn json_error_handler(err: error::JsonPayloadError, _req: &HttpRequest) -> error::Error {
+    use actix_web::error::JsonPayloadError;
+
     let detail = format!("{}", err);
-    error::InternalError::from_response(
-        err,
-        HttpResponse::UnprocessableEntity().body(detail),
-    )
-    .into()
+    let resp = match &err {
+        JsonPayloadError::ContentType => {
+            HttpResponse::UnsupportedMediaType().body(detail)
+        }
+        JsonPayloadError::Deserialize(json_err) if json_err.is_data() => {
+            HttpResponse::UnprocessableEntity().body(detail)
+        }
+        _ => HttpResponse::BadRequest().body(detail),
+    };
+    error::InternalError::from_response(err, resp).into()
 }
 
 #[actix_rt::main]

--- a/json_decode_error/src/main.rs
+++ b/json_decode_error/src/main.rs
@@ -1,0 +1,34 @@
+use actix_web::{
+    error, post, web, App, FromRequest, HttpRequest, HttpResponse, HttpServer, Responder,
+};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Info {
+    name: String,
+}
+
+#[post("/")]
+async fn greet(name: web::Json<Info>) -> impl Responder {
+    HttpResponse::Ok().body(format!("Hello {}!", name.name))
+}
+
+fn json_error_handler(err: error::JsonPayloadError, _req: &HttpRequest) -> error::Error {
+    let detail = format!("{}", err);
+    error::InternalError::from_response(err, HttpResponse::UnprocessableEntity().body(detail))
+        .into()
+}
+
+#[actix_rt::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| {
+        App::new()
+            .service(greet)
+            .app_data(web::Json::<Info>::configure(|cfg| {
+                cfg.error_handler(json_error_handler)
+            }))
+    })
+    .bind("127.0.0.1:8088")?
+    .run()
+    .await
+}

--- a/json_decode_error/src/main.rs
+++ b/json_decode_error/src/main.rs
@@ -16,7 +16,7 @@ async fn greet(name: web::Json<Info>) -> impl Responder {
 fn json_error_handler(err: error::JsonPayloadError, _req: &HttpRequest) -> error::Error {
     use actix_web::error::JsonPayloadError;
 
-    let detail = format!("{}", err);
+    let detail = err.to_string();
     let resp = match &err {
         JsonPayloadError::ContentType => {
             HttpResponse::UnsupportedMediaType().body(detail)


### PR DESCRIPTION
A demonstration of how you can return something more informative to the client than an empty HTTP 400 in cases where deserializing a JSON payload fails.

Please let me know if the coding style, documentation, naming or anything else can be improved, I am not very experienced with programming in Rust yet!