### PR TITLE
Add bare-bones WS server for autobahn testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
    "unix-socket",
    "web-cors/backend",
    "websocket",
+   "websocket-autobahn",
    "websocket-chat",
    "websocket-chat-broker",
    "websocket-tcp-chat",

--- a/websocket-autobahn/Cargo.toml
+++ b/websocket-autobahn/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "websocket-autobahn"
+version = "2.0.0"
+authors = ["Mark Lodato <mlodato517@gmail.com"]
+edition = "2018"
+
+[[bin]]
+name = "websocket-autobahn-server"
+path = "src/main.rs"
+
+[dependencies]
+actix = "0.9.0"
+actix-web = "2.0.0"
+actix-web-actors = "2.0.0"
+actix-rt = "1.0.0"
+env_logger = "0.7"

--- a/websocket-autobahn/README.md
+++ b/websocket-autobahn/README.md
@@ -13,27 +13,21 @@ cargo run --bin websocket-autobahn-server
 
 ### Running Autobahn Test Suite
 
-Follow the steps from the [autobahn-testsuite repo](https://github.com/crossbario/autobahn-testsuite#using-the-testsuite-docker-image)
-to install the necessary prerequisites.
+Running the autobahn test suite is easiest using the docker image
+as explained on the [autobahn-testsuite repo](https://github.com/crossbario/autobahn-testsuite#using-the-testsuite-docker-image).
 
-For example:
-
-```bash
-virtualenv ~/wstest
-source ~/wstest/bin/activate
-pip install autobahntestsuite
-```
-
-Once prerequisites are installed, run the test suite:
+First, start a server (see above). Then, run the test suite in fuzzingclient mode:
 
 ```bash
-# In one window, start the server
-cd examples/websocket-autobahn
-cargo run --bin websocket-autobahn-server
-
-# In another window, start the tests
-cd ~
-mkdir test
-cd test
-wstest -m fuzzingclient
+docker run -it --rm \
+    -v "${PWD}/config:/config" \
+    -v "${PWD}/reports:/reports" \
+    --network host \
+    --name autobahn \
+    crossbario/autobahn-testsuite \
+    wstest \
+    --spec /config/fuzzingclient.json \
+    --mode fuzzingclient
 ```
+
+Results are written to the `reports/servers` directory for viewing.

--- a/websocket-autobahn/README.md
+++ b/websocket-autobahn/README.md
@@ -1,0 +1,39 @@
+# websocket
+
+Websocket server for autobahn suite testing.
+
+## Usage
+
+### server
+
+```bash
+cd examples/websocket-autobahn
+cargo run --bin websocket-autobahn-server
+```
+
+### Running Autobahn Test Suite
+
+Follow the steps from the [autobahn-testsuite repo](https://github.com/crossbario/autobahn-testsuite#using-the-testsuite-docker-image)
+to install the necessary prerequisites.
+
+For example:
+
+```bash
+virtualenv ~/wstest
+source ~/wstest/bin/activate
+pip install autobahntestsuite
+```
+
+Once prerequisites are installed, run the test suite:
+
+```bash
+# In one window, start the server
+cd examples/websocket-autobahn
+cargo run --bin websocket-autobahn-server
+
+# In another window, start the tests
+cd ~
+mkdir test
+cd test
+wstest -m fuzzingclient
+```

--- a/websocket-autobahn/config/fuzzingclient.json
+++ b/websocket-autobahn/config/fuzzingclient.json
@@ -7,6 +7,9 @@
     }
   ],
   "cases": ["*"],
-  "exclude-cases": [],
+  "exclude-cases": [
+    "12.*",
+    "13.*"
+  ],
   "exclude-agent-cases": {}
 }

--- a/websocket-autobahn/config/fuzzingclient.json
+++ b/websocket-autobahn/config/fuzzingclient.json
@@ -1,0 +1,12 @@
+{
+  "outdir": "./reports/servers",
+  "servers": [
+    {
+      "agent": "actix-web-actors",
+      "url": "ws://host.docker.internal:9001"
+    }
+  ],
+  "cases": ["*"],
+  "exclude-cases": [],
+  "exclude-agent-cases": {}
+}

--- a/websocket-autobahn/reports/.gitignore
+++ b/websocket-autobahn/reports/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/websocket-autobahn/src/main.rs
+++ b/websocket-autobahn/src/main.rs
@@ -1,0 +1,55 @@
+use actix::prelude::*;
+use actix_web::{middleware, web, App, Error, HttpRequest, HttpResponse, HttpServer};
+use actix_web_actors::ws;
+
+async fn ws_index(r: HttpRequest, stream: web::Payload) -> Result<HttpResponse, Error> {
+    ws::start(WebSocket::new(), &r, stream)
+}
+
+struct WebSocket {}
+
+impl Actor for WebSocket {
+    type Context = ws::WebsocketContext<Self>;
+
+    fn started(&mut self, _ctx: &mut Self::Context) {}
+}
+
+impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebSocket {
+    fn handle(
+        &mut self,
+        msg: Result<ws::Message, ws::ProtocolError>,
+        ctx: &mut Self::Context,
+    ) {
+        if let Ok(msg) = msg {
+            match msg {
+                ws::Message::Text(text) => ctx.text(text),
+                ws::Message::Binary(bin) => ctx.binary(bin),
+                ws::Message::Ping(bytes) => ctx.pong(&bytes),
+                _ => {}
+            }
+        } else {
+            ctx.stop();
+        }
+    }
+}
+
+impl WebSocket {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+#[actix_rt::main]
+async fn main() -> std::io::Result<()> {
+    std::env::set_var("RUST_LOG", "actix_server=info,actix_web=info");
+    env_logger::init();
+
+    HttpServer::new(|| {
+        App::new()
+            .wrap(middleware::Logger::default())
+            .service(web::resource("/").route(web::get().to(ws_index)))
+    })
+    .bind("127.0.0.1:9001")?
+    .run()
+    .await
+}


### PR DESCRIPTION
**This PR**
Hopefully creates a minimal autobahn websocket server example from which to start testing and addressing issues for https://github.com/actix/actix-web/issues/1006.

I assume this example needs to be tweaked slightly to make a reasonable benchmark. From there I can run the autobahn test suite and document all the failures. Then we can pick them off as we see fit.