### PR TITLE
Fix function name that camel to snake

### DIFF
--- a/juniper/src/schema.rs
+++ b/juniper/src/schema.rs
@@ -45,7 +45,7 @@ pub struct MutationRoot;
 
 #[juniper::object]
 impl MutationRoot {
-    fn createHuman(new_human: NewHuman) -> FieldResult<Human> {
+    fn create_human(new_human: NewHuman) -> FieldResult<Human> {
         Ok(Human {
             id: "1234".to_owned(),
             name: new_human.name,


### PR DESCRIPTION
Juniper crate can interconvert a GraphQL camel function and a Rust snake function.
So a function name in Rust should be snake case.
Actually, functions are written by snake case in juniper-advenced.

https://github.com/actix/examples/blob/master/juniper-advanced/src/schemas/root.rs#L104