### PR TITLE
Update udp-echo example to actix 0.9 and tokio 0.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
    "template_tera",
    "template_yarte",
    "todo",
-#   "udp-echo",
+   "udp-echo",
    "unix-socket",
    "web-cors/backend",
    "websocket",

--- a/udp-echo/Cargo.toml
+++ b/udp-echo/Cargo.toml
@@ -5,7 +5,10 @@ authors = ["Anton Patrushev <apatrushev@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-actix = "0.7"
-tokio = "0.1"
-futures = "0.1"
-bytes = "0.4"
+actix = "0.9"
+actix-rt = "1.1"
+tokio = "0.2"
+tokio-util = { version = "0.3", features = [ "codec", "udp" ] }
+futures = "0.3"
+futures-util = "0.3"
+bytes = "0.5"


### PR DESCRIPTION
The current `udp-echo` example is based on `actix` `0.7` and `tokio` `0.1` and it is too old to be really useful.

This PR updates the code to be compatible and use the current version of `actix` and `tokio`.

Because of the refactors of the dependencies new dependencies came in:
  * `tokio-util`
  * `futures-util`

Closes #292 