### PR TITLE
Example tip for key.pem to work

### DIFF
--- a/rustls/README.md
+++ b/rustls/README.md
@@ -18,6 +18,11 @@ If you want to generate your own cert/private key file, then run:
 mkcert 127.0.0.1
 ```
 
+If your key doesn't work, convert it to rsa:
+```bash
+openssl rsa -in key.pem -out key-rsa.pem
+```
+
 [`mkcert`]: https://github.com/FiloSottile/mkcert
 
 ### server


### PR DESCRIPTION
For some reason mkcert default generated sertificate doesn't work. Only after you convert it to rsa problem goes away.

```
    let mut tls_config = ServerConfig::new(NoClientAuth::new());
    let cert_file = &mut BufReader::new(File::open("./tls/localhost/cert.pem").unwrap());
    let key_file = &mut BufReader::new(File::open("./tls/localhost/key.pem").unwrap());
    let cert_chain = certs(cert_file).unwrap();
    let mut keys = rsa_private_keys(key_file).unwrap();
    tls_config
        .set_single_cert(cert_chain, keys.remove(0))
        .unwrap();
```

Rust panic on `keys.remove(0)`.