### PR TITLE
Fix rustls example to support pkcs8 keys

### DIFF
--- a/rustls/README.md
+++ b/rustls/README.md
@@ -15,12 +15,13 @@ mkcert -install
 If you want to generate your own cert/private key file, then run:
 
 ```bash
-mkcert 127.0.0.1
+mkcert 127.0.0.1 localhost
 ```
 
-If your key doesn't work, convert it to rsa:
-```bash
-openssl rsa -in key.pem -out key-rsa.pem
+For `rsa` keys use `rsa_private_keys` function instead `pkcs8_private_keys`
+```
+let mut keys = pkcs8_private_keys(key_file).unwrap(); // pkcs8
+let mut keys = rsa_private_keys(key_file).unwrap(); // rsa
 ```
 
 [`mkcert`]: https://github.com/FiloSottile/mkcert

--- a/rustls/src/main.rs
+++ b/rustls/src/main.rs
@@ -3,7 +3,7 @@ use std::io::BufReader;
 
 use actix_files::Files;
 use actix_web::{middleware, web, App, HttpRequest, HttpResponse, HttpServer};
-use rustls::internal::pemfile::{certs, rsa_private_keys};
+use rustls::internal::pemfile::{certs, pkcs8_private_keys};
 use rustls::{NoClientAuth, ServerConfig};
 
 /// simple handle
@@ -28,7 +28,7 @@ async fn main() -> std::io::Result<()> {
     let cert_file = &mut BufReader::new(File::open("cert.pem").unwrap());
     let key_file = &mut BufReader::new(File::open("key.pem").unwrap());
     let cert_chain = certs(cert_file).unwrap();
-    let mut keys = rsa_private_keys(key_file).unwrap();
+    let mut keys = pkcs8_private_keys(key_file).unwrap();
     config.set_single_cert(cert_chain, keys.remove(0)).unwrap();
 
     HttpServer::new(|| {


### PR DESCRIPTION
By default `mkcert` and I think Let's Encrypt will generate `pkcs8` keys. This PR fix default key usage and ads tip for `rsa` keys.