### PR TITLE
Update the examples list

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,10 @@ A curated list of examples related to actix.
 ## from community
 * [Roseline](https://github.com/DoumanAsh/roseline.rs) : A personal web site and discord & IRC bot to access simple SQLite database. Demonstrates usage of various actix and actix-web concepts.
 * [Actix Auth Server](https://hgill.io/posts/auth-microservice-rust-actix-web-diesel-complete-tutorial-part-1/) : Auth web micro-service with rust using actix-web - complete tutorial. See code in [examples/simple-auth-server](https://github.com/actix/examples/tree/master/simple-auth-server)
-* [Casbin-RS](https://github.com/casbin/casbin-rs) : An authorization library that supports access control models like ACL, RBAC, ABAC in Rust. See code in [examples/casbin](https://github.com/actix/examples/tree/master/casbin)
-* [actix-raft](https://github.com/railgun-rs/actix-raft) : An implementation of the Raft consensus protocol using the actix Actor framework.
+* [Actix Casbin](https://github.com/casbin-rs/actix-casbin) : An authorization library that supports access control models like ACL, RBAC, ABAC in Rust.
 * [lemmy](https://github.com/dessalines/lemmy) : A federated alternative to reddit in rust.
 * [actix-realworld-example-app](https://github.com/fairingrey/actix-realworld-example-app) : Implementation of the RealWorld backend API spec in Actix.
 * [Canduma](https://github.com/clifinger/canduma) : rust authentication server boilerplate
-* [Broker](https://crates.io/crates/broker) : Real-time Zero-Code API Server
 * [Rust, Docker & GraphQL](https://github.com/jayy-lmao/rust-graphql-docker): An example of using Dataloaders, context, and a minimal docker container. 
 * [Complete Actix 2.x REST Server](https://github.com/ddimaria/rust-actix-example): Actix 2.x HTTP Server featuring multi-database support, auth/JWTs, caching, static files, app state, tests, coverage, and docker.
 * [Actix Server Authentication with JWT and MongoDB](https://github.com/emreyalvac/actix-web-jwt/) : An implementation of JWT in Actix.


### PR DESCRIPTION
:heavy_check_mark: **Changes:**
- **Replaced `Casbin-RS` with `Actix-Casbin`**: `Casbin-RS` is not written using Actix although there is an Actix integration of Casbin at https://github.com/casbin-rs/actix-casbin.
- **Removed `actix-raft`**: `actix-raft` is now [`async-raft`](https://github.com/async-raft/async-raft) and no longer uses Actix, they ported their codebase to use the [Tokio](https://github.com/tokio-rs/tokio) framework.
- **Removed `Broker`**: Broker no longer uses Actix, they ported their codebase to use the [Portal](https://docs.rs/portal/0.2.3/portal/) framework (hard-fork of [warp](https://github.com/seanmonstar/warp)).

:books: **Sources:**
- https://github.com/casbin/casbin-rs/issues/82
- https://github.com/apibillme/broker/issues/6
- https://github.com/apibillme/broker/pull/7