### PR TITLE
add Cors to get juniper example to work.

### DIFF
--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 actix-web = "3"
-actix-cors = "0.3.0"
+actix-cors = "0.4.0"
 env_logger = "0.7.1"
 serde = "1.0.103"
 serde_json = "1.0.44"

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 actix-web = "3"
+actix-cors = "0.3.0"
 env_logger = "0.7.1"
 serde = "1.0.103"
 serde_json = "1.0.44"

--- a/juniper/src/main.rs
+++ b/juniper/src/main.rs
@@ -4,6 +4,7 @@
 use std::io;
 use std::sync::Arc;
 
+use actix_cors::Cors;
 use actix_web::{middleware, web, App, Error, HttpResponse, HttpServer};
 use juniper::http::graphiql::graphiql_source;
 use juniper::http::GraphQLRequest;
@@ -46,6 +47,13 @@ async fn main() -> io::Result<()> {
         App::new()
             .data(schema.clone())
             .wrap(middleware::Logger::default())
+            .wrap(
+                Cors::new()
+                    .allowed_methods(vec!["POST", "GET"])
+                    .supports_credentials()
+                    .max_age(3600)
+                    .finish(),
+            )
             .service(web::resource("/graphql").route(web::post().to(graphql)))
             .service(web::resource("/graphiql").route(web::get().to(graphiql)))
     })


### PR DESCRIPTION
Added actix_cors to get Juniper example to work. The example wouldn't work without it for me. I'm on macOS Catalina using Firefox and Safari browsers. The example would fail with a network error.