### PR TITLE
fix version mismatch of "@vue/cli-service"

### DIFF
--- a/web-cors/frontend/package.json
+++ b/web-cors/frontend/package.json
@@ -7,10 +7,10 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
-    "vue": "2.6.10"
+    "vue": "2.6.12"
   },
   "devDependencies": {
     "@vue/cli-service": "^3.0.0",
-    "vue-template-compiler": "^2.5.21"
+    "vue-template-compiler": "^2.6.12"
   }
 }


### PR DESCRIPTION
**I tested on my local machine and got a version mismatch, then fixed by changing to the same version.**

`$ npm run serve

> frontend-vue@0.1.0 serve /home/user/rust/examples/web-cors/frontend
> vue-cli-service serve

 INFO  Starting development server...
98% after emitting

 ERROR  Failed to compile with 2 errors                                   1:58:01 PM

 error  in ./src/app.vue

Module Error (from ./node_modules/vue-loader/lib/index.js):


Vue packages version mismatch:

- vue@2.6.10 (/home/user/rust/examples/web-cors/frontend/node_modules/vue/dist/vue.runtime.common.js)
- vue-template-compiler@2.6.12 (/home/user/rust/examples/web-cors/frontend/node_modules/vue-template-compiler/package.json)

This may cause things to work incorrectly. Make sure to use the same version for both.
If you are using vue-loader@>=10.0, simply update vue-template-compiler.
If you are using vue-loader@<10.0 or vueify, re-installing vue-loader/vueify should bump vue-template-compiler to the latest.` 