### PR TITLE
web-cors: Update `actix-cors` to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "actix-cors"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48de0a29c99c8a5068c1c5492f6e477ef1843cc5e3c53daa0191562b71950632"
+checksum = "d88ea83af46935098feec2e19a28c919b54eb3cbf0e239b330298e2e69d4b76b"
 dependencies = [
  "actix-service",
  "actix-web 3.0.0",
@@ -3113,6 +3113,7 @@ dependencies = [
 name = "juniper-example"
 version = "0.2.0"
 dependencies = [
+ "actix-cors",
  "actix-web 3.0.0",
  "env_logger 0.7.1",
  "juniper",

--- a/web-cors/backend/Cargo.toml
+++ b/web-cors/backend/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 actix-web = "3"
-actix-cors = "0.3"
+actix-cors = "0.4"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
#371 added actix-cors 0.4 but it didn't update the lockfile. And we use the cors 0.3 in the `web-cors` example so we have two versions of the cors currently, this updates the latter and the lockfile.