### PR TITLE
Fix a broken link

### DIFF
--- a/graphql/juniper/README.md
+++ b/graphql/juniper/README.md
@@ -3,7 +3,7 @@
 [Juniper](https://github.com/graphql-rust/juniper) integration for Actix web.
 If you want more advanced example, see also the [juniper-advanced example].
 
-[juniper-advanced example]: https://github.com/actix/examples/tree/master/juniper-advanced
+[juniper-advanced example]: https://github.com/actix/examples/tree/master/graphql/juniper-advanced
 
 ## Usage
 


### PR DESCRIPTION
The link to the `juniper-advanced` example is missing the `graphql` part of the path.