### PR TITLE
Update rustls-client-cert README to use httpie verify

### DIFF
--- a/security/rustls-client-cert/README.md
+++ b/security/rustls-client-cert/README.md
@@ -20,8 +20,7 @@ The server runs HTTP on port 8080 and HTTPS on port 8443.
 
 Using [HTTPie]:
 ```sh
-# `--verify=false` used because HTTPie doesn't have an option to provide the CA cert
-http https://127.0.0.1:8443/ --verify=false --cert=certs/client-cert.pem --cert-key=certs/client-key.pem
+http https://127.0.0.1:8443/ --verify=certs/rootCA.pem --cert=certs/client-cert.pem --cert-key=certs/client-key.pem
 ```
 
 Using [cURL]:


### PR DESCRIPTION
This PR updates the README in the  rustls-client-cert example to demonstrate [how to pass in the rootCA with httpie](https://httpie.io/docs#custom-ca-bundle). 