### PR TITLE
[EZ] Update comment with correct URL.

### DIFF
--- a/websockets/websocket/src/main.rs
+++ b/websockets/websocket/src/main.rs
@@ -1,5 +1,5 @@
 //! Simple echo websocket server.
-//! Open `http://localhost:8080/ws/index.html` in browser
+//! Open `http://localhost:8080/index.html` in browser
 //! or [python console client](https://github.com/actix/examples/blob/master/websocket/websocket-client.py)
 //! could be used for testing.
 


### PR DESCRIPTION
http://localhost:8080/ws/index.html gives a 404.  The running server serves `index.html` for the page, and connects to the websocket on `/ws`.

See below:
https://github.com/actix/examples/blob/c3407627d0e45ee8883b1c7d1dc84251ecc6d9a1/websockets/websocket/src/main.rs#L108-L110