### PR TITLE
fix database_interactions/sqlx_todo example

### DIFF
--- a/database_interactions/sqlx_todo/README.md
+++ b/database_interactions/sqlx_todo/README.md
@@ -20,7 +20,7 @@ cd examples/sqlx_todo
 ## Set up the database
 
 * Create new database using `schema.sql`
-* Copy `.env-example` into `.env` and adjust DATABASE_URL to match your SQLite address, username and password 
+* Copy `.env-example` into `.env` and adjust DATABASE_URL to match your SQLite address
 
 ## Run the application
 


### PR DESCRIPTION
Given 'sqlite' is a prerequisite for this example, 'readme.md' is mod…ified as 'username and password' is not required for 'sqlite'.

File 'model.rs' is also modified in order to amend queries and transactions for 'create' and 'update' functions.