### PR TITLE
Use smaller Debian base image in example

### DIFF
--- a/basics/docker_sample/Dockerfile
+++ b/basics/docker_sample/Dockerfile
@@ -15,7 +15,7 @@ FROM base AS builder
 
 RUN cargo build --release --offline
 
-FROM rust:1-slim-buster
+FROM debian:buster-slim
 
 COPY --from=builder /code/target/release/docker_sample /usr/bin/docker_sample
 


### PR DESCRIPTION
The Docker sample project builds the Docker container using the `rust:1-slim-buster` image, that contains the full Rust toolchain to compile the sample application. The final container does not require the toolchain to run the application with, therefore the smaller Debian base image `buster-slim` is sufficient.

This reduces the image size from about ~626 Mb down to ~80 Mb.