### PR TITLE
Add atomic-server to Community Showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [lemmy](https://github.com/dessalines/lemmy): A federated alternative to reddit in Rust.
 - [MeiliSearch](https://github.com/meilisearch/MeiliSearch): Fast, Relevant and Typo-Tolerant Search Engine. Open source alternative to Algolia.
 - [Dalted](https://github.com/carrascomj/dalted): Simple webapp that showcases the integration of [image-rs](https://github.com/image-rs/image) with Actix Web for color blindness simulations.
+- [Atomic-Server](https://github.com/joepio/atomic-data-rust/): Graph database with a dynamic schema, authorization and full text search.
 
 ## Community Articles, Example Apps, Starters & Boilerplate Projects
 


### PR DESCRIPTION
Hi there! I've been using Actix for a while now, and really like it. It offers great performance for my project, [atomic-server](https://github.com/joepio/atomic-data-rust/). Would you like to add it to the showcase list in the examples readme?