### PR TITLE
add logger for askama template example

### DIFF
--- a/template_engines/askama/Cargo.toml
+++ b/template_engines/askama/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+env_logger = "0.8"
 actix-web = "3"
 askama = "0.9"
 

--- a/template_engines/askama/src/main.rs
+++ b/template_engines/askama/src/main.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use actix_web::{web, App, HttpResponse, HttpServer, Result};
+use actix_web::{middleware, web, App, HttpResponse, HttpServer, Result};
 use askama::Template;
 
 #[derive(Template)]
@@ -30,9 +30,14 @@ async fn index(query: web::Query<HashMap<String, String>>) -> Result<HttpRespons
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    std::env::set_var("RUST_LOG", "actix_web=info");
+    env_logger::init();
+
     // start http server
     HttpServer::new(move || {
-        App::new().service(web::resource("/").route(web::get().to(index)))
+        App::new()
+            .wrap(middleware::Logger::default())
+            .service(web::resource("/").route(web::get().to(index)))
     })
     .bind("127.0.0.1:8080")?
     .run()


### PR DESCRIPTION
Only askama in the template example did not have a Logger.

If you are able to accept the changes here, please consider it.