### PR TITLE
Fix deadlock in casbin example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "loge",
  "rhai",
  "rhai_codegen",
+ "tokio 0.2.25",
 ]
 
 [[package]]

--- a/security/casbin/Cargo.toml
+++ b/security/casbin/Cargo.toml
@@ -13,4 +13,4 @@ casbin = "=2.0.5"
 rhai = "=0.19.14"
 rhai_codegen = "=0.3.3"
 loge = {version = "0.4", default-features = false, features = ["colored", "chrono"]}
-tokio = {version= "*", features = ["sync"]}
+tokio = { version = "0.2.22", features = ["sync"] }

--- a/security/casbin/Cargo.toml
+++ b/security/casbin/Cargo.toml
@@ -13,3 +13,4 @@ casbin = "=2.0.5"
 rhai = "=0.19.14"
 rhai_codegen = "=0.3.3"
 loge = {version = "0.4", default-features = false, features = ["colored", "chrono"]}
+tokio = {version= "*", features = ["sync"]}

--- a/security/casbin/src/main.rs
+++ b/security/casbin/src/main.rs
@@ -1,6 +1,6 @@
 use casbin::{CoreApi, DefaultModel, Enforcer, FileAdapter, RbacApi};
 use std::io;
-use std::sync::RwLock;
+use tokio::sync::RwLock;
 
 use actix_web::{middleware, web, App, HttpRequest, HttpResponse, HttpServer};
 
@@ -9,7 +9,7 @@ async fn success(
     enforcer: web::Data<RwLock<Enforcer>>,
     req: HttpRequest,
 ) -> HttpResponse {
-    let mut e = enforcer.write().unwrap();
+    let mut e = enforcer.write().await;
     println!("{:?}", req);
     assert_eq!(vec!["data2_admin"], e.get_roles_for_user("alice", None));
 
@@ -17,7 +17,7 @@ async fn success(
 }
 
 async fn fail(enforcer: web::Data<RwLock<Enforcer>>, req: HttpRequest) -> HttpResponse {
-    let mut e = enforcer.write().unwrap();
+    let mut e = enforcer.write().await;
     println!("{:?}", req);
     assert_eq!(vec!["data1_admin"], e.get_roles_for_user("alice", None));
 


### PR DESCRIPTION
...by exchanging the std::sync::RwLock with a
async_std::sync::RwLock. This could also have been the tokio
equivalent but I've used async_std::sync::RwLock as it has nearly the
same API as its std counterpart used in the original casbin example code.

Closes #470