### PR TITLE
Updated basics/shutdown-server to v4.

### DIFF
--- a/basics/shutdown-server/Cargo.toml
+++ b/basics/shutdown-server/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "Send a request to the server to shut it down"
 
 [dependencies]
-actix-web = "3"
-env_logger = "0.8"
+actix-web = "4.0.0-beta.21"
+env_logger = "0.9"
 futures = "0.3"
-tokio = { version = "0.2", features = ["signal"] }
+tokio = { version = "1.16", features = ["signal"] }

--- a/basics/shutdown-server/src/main.rs
+++ b/basics/shutdown-server/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> std::io::Result<()> {
     let server = HttpServer::new(move || {
         // give the server a Sender in .data
         App::new()
-            .data(tx.clone())
+            .app_data(tx.clone())
             .wrap(middleware::Logger::default())
             .service(hello)
             .service(stop)
@@ -38,7 +38,7 @@ async fn main() -> std::io::Result<()> {
     .run();
 
     // clone the Server handle
-    let srv = server.clone();
+    let srv = server.handle();
     thread::spawn(move || {
         // wait for shutdown signal
         rx.recv().unwrap();

--- a/basics/shutdown-server/src/main.rs
+++ b/basics/shutdown-server/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> std::io::Result<()> {
     let server = HttpServer::new(move || {
         // give the server a Sender in .data
         App::new()
-            .app_data(tx.clone())
+            .app_data(web::Data::new(tx.clone()))
             .wrap(middleware::Logger::default())
             .service(hello)
             .service(stop)


### PR DESCRIPTION
Moved from `data` to `app_data` in the constructor for `HttpServer`. Rather than cloning the server we now get the handle with `.handle()`.