### PR TITLE
Update basics/middleware to v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3542,11 +3542,11 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 name = "middleware-example"
 version = "2.0.0"
 dependencies = [
- "actix-service 1.0.6",
- "actix-web 3.3.3",
- "env_logger 0.8.4",
+ "actix-service 2.0.2",
+ "actix-web 4.0.0-beta.21",
+ "env_logger 0.9.0",
  "futures",
- "pin-project 0.4.29",
+ "pin-project 1.0.10",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3542,7 +3542,6 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 name = "middleware-example"
 version = "2.0.0"
 dependencies = [
- "actix-service 2.0.2",
  "actix-web 4.0.0-beta.21",
  "env_logger 0.9.0",
  "futures",

--- a/basics/middleware/Cargo.toml
+++ b/basics/middleware/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["Gorm Casper <gcasper@gmail.com>", "Sven-Hendrik Haase <svenstaro@gma
 edition = "2018"
 
 [dependencies]
-actix-service = "2"
 actix-web = "4.0.0-beta.21"
-env_logger = "0.9.0"
-futures = "0.3.1"
-pin-project = "1.0.10"
+env_logger = "0.9"
+futures = "0.3.7"
+pin-project = "1"

--- a/basics/middleware/Cargo.toml
+++ b/basics/middleware/Cargo.toml
@@ -5,9 +5,8 @@ authors = ["Gorm Casper <gcasper@gmail.com>", "Sven-Hendrik Haase <svenstaro@gma
 edition = "2018"
 
 [dependencies]
-actix-service = "1"
-actix-web = "3"
-
-env_logger = "0.8"
+actix-service = "2"
+actix-web = "4.0.0-beta.21"
+env_logger = "0.9.0"
 futures = "0.3.1"
-pin-project = "0.4"
+pin-project = "1.0.10"

--- a/basics/middleware/src/main.rs
+++ b/basics/middleware/src/main.rs
@@ -1,8 +1,5 @@
-#![allow(clippy::type_complexity)]
-
-use actix_service::Service;
-use actix_web::{web, App, HttpServer};
-use futures::future::FutureExt;
+use actix_web::{dev::Service, web, App, HttpServer};
+use futures::FutureExt as _;
 
 #[allow(dead_code)]
 mod read_request_body;

--- a/basics/middleware/src/read_response_body.rs
+++ b/basics/middleware/src/read_response_body.rs
@@ -4,19 +4,18 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use actix_service::{Service, Transform};
-use actix_web::body::{BodySize, MessageBody, ResponseBody};
+use actix_web::body::{BodySize, MessageBody};
 use actix_web::web::{Bytes, BytesMut};
 use actix_web::{dev::ServiceRequest, dev::ServiceResponse, Error};
 use futures::future::{ok, Ready};
 
 pub struct Logging;
 
-impl<S: 'static, B> Transform<S> for Logging
+impl<S: 'static, B> Transform<S, ServiceRequest> for Logging
 where
-    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
     B: MessageBody + 'static,
 {
-    type Request = ServiceRequest;
     type Response = ServiceResponse<BodyLogger<B>>;
     type Error = Error;
     type InitError = ();
@@ -32,21 +31,20 @@ pub struct LoggingMiddleware<S> {
     service: S,
 }
 
-impl<S, B> Service for LoggingMiddleware<S>
+impl<S, B> Service<ServiceRequest> for LoggingMiddleware<S>
 where
-    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
     B: MessageBody,
 {
-    type Request = ServiceRequest;
     type Response = ServiceResponse<BodyLogger<B>>;
     type Error = Error;
     type Future = WrapperStream<S, B>;
 
-    fn poll_ready(&mut self, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&self, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
         self.service.poll_ready(cx)
     }
 
-    fn call(&mut self, req: ServiceRequest) -> Self::Future {
+    fn call(&self, req: ServiceRequest) -> Self::Future {
         WrapperStream {
             fut: self.service.call(req),
             _t: PhantomData,
@@ -58,7 +56,7 @@ where
 pub struct WrapperStream<S, B>
 where
     B: MessageBody,
-    S: Service,
+    S: Service<ServiceRequest>,
 {
     #[pin]
     fut: S::Future,
@@ -68,7 +66,7 @@ where
 impl<S, B> Future for WrapperStream<S, B>
 where
     B: MessageBody,
-    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
 {
     type Output = Result<ServiceResponse<BodyLogger<B>>, Error>;
 
@@ -76,31 +74,31 @@ where
         let res = futures::ready!(self.project().fut.poll(cx));
 
         Poll::Ready(res.map(|res| {
-            res.map_body(move |_, body| {
-                ResponseBody::Body(BodyLogger {
-                    body,
-                    body_accum: BytesMut::new(),
-                })
+            res.map_body(move |_, body| BodyLogger {
+                body,
+                body_accum: BytesMut::new(),
             })
         }))
     }
 }
 
 #[pin_project::pin_project(PinnedDrop)]
-pub struct BodyLogger<B> {
+pub struct BodyLogger<B: MessageBody> {
     #[pin]
-    body: ResponseBody<B>,
+    body: B,
     body_accum: BytesMut,
 }
 
 #[pin_project::pinned_drop]
-impl<B> PinnedDrop for BodyLogger<B> {
+impl<B: MessageBody> PinnedDrop for BodyLogger<B> {
     fn drop(self: Pin<&mut Self>) {
         println!("response body: {:?}", self.body_accum);
     }
 }
 
 impl<B: MessageBody> MessageBody for BodyLogger<B> {
+    type Error = B::Error;
+
     fn size(&self) -> BodySize {
         self.body.size()
     }
@@ -108,7 +106,7 @@ impl<B: MessageBody> MessageBody for BodyLogger<B> {
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Bytes, Error>>> {
+    ) -> Poll<Option<Result<Bytes, Self::Error>>> {
         let this = self.project();
 
         match this.body.poll_next(cx) {

--- a/basics/middleware/src/simple.rs
+++ b/basics/middleware/src/simple.rs
@@ -1,10 +1,10 @@
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::future::{ready, Ready};
 
-use actix_service::{Service, Transform};
-use actix_web::{dev::ServiceRequest, dev::ServiceResponse, Error};
-use futures::future::{ok, Ready};
-use futures::Future;
+use actix_web::{
+    dev::{self, Service, ServiceRequest, ServiceResponse, Transform},
+    Error,
+};
+use futures::future::LocalBoxFuture;
 
 // There are two steps in middleware processing.
 // 1. Middleware initialization, middleware factory gets called with
@@ -28,7 +28,7 @@ where
     type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
     fn new_transform(&self, service: S) -> Self::Future {
-        ok(SayHiMiddleware { service })
+        ready(Ok(SayHiMiddleware { service }))
     }
 }
 
@@ -44,11 +44,9 @@ where
 {
     type Response = ServiceResponse<B>;
     type Error = Error;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
 
-    fn poll_ready(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.service.poll_ready(cx)
-    }
+    dev::forward_ready!(service);
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
         println!("Hi from start. You requested: {}", req.path());


### PR DESCRIPTION
I struggled quite a bit with the redirect middleware due to the requirement of unifying the two different body types (a concrete `BoxBody` with a generic `B` body). 
In the end I opted to use an async block because spelling out the type of `MapOk`, required to call `map_into_boxed_body` on the future returned by `service.call`, was getting out of hand.