### PR TITLE
Update basics/middleware-ext-mut to v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,8 +3553,9 @@ dependencies = [
 name = "middleware-ext-mut"
 version = "0.1.0"
 dependencies = [
- "actix-web 3.3.3",
+ "actix-web 4.0.0-beta.21",
  "env_logger 0.9.0",
+ "log",
 ]
 
 [[package]]

--- a/basics/middleware-ext-mut/Cargo.toml
+++ b/basics/middleware-ext-mut/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Eric McCarthy <ericmccarthy7@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-actix-web = "3"
-
+actix-web = "4.0.0-beta.21"
+log = "0.4"
 env_logger = "0.9"

--- a/basics/middleware-ext-mut/README.md
+++ b/basics/middleware-ext-mut/README.md
@@ -1,6 +1,6 @@
 # middleware examples
 
-This example showcases a middleware that adds and retreives request-local data. See also the [Middleware guide](https://actix.rs/docs/middleware/).
+This example showcases a middleware that adds and retrieves request-local data. See also the [Middleware guide](https://actix.rs/docs/middleware/).
 
 ## Usage
 


### PR DESCRIPTION
I switched `println!` to be `log::info` given that the example initialises a logger.
I also simplified the trait bounds on the middleware itself.