### PR TITLE
Updated basics/middleware-http-to-https to v4.

### DIFF
--- a/basics/middleware-http-to-https/Cargo.toml
+++ b/basics/middleware-http-to-https/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = {version = "3", features = ["rustls"]}
-rustls = "0.18"
+actix-web = {version = "4.0.0-beta.21", features = ["rustls"]}
+rustls = "0.20.2"
+rustls-pemfile = "0.2.1" # these are now in an external library
 futures = "0.3"
 
 


### PR DESCRIPTION
I needed to add a new dependency `rustls-pemfile` as the functions for parsing pemfiles are no longer in the core `rustls`.  The `main` function has expanded as the keys and certificates now need to move into `Certificate` and `PrivateKey` structs to be parsed into the `config`.