### PR TITLE
Update template-engines/handlerbars to v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2811,9 +2811,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "3.5.5"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4498fc115fa7d34de968184e473529abb40eeb6be8bc5f7faba3d08c316cb3e3"
+checksum = "25546a65e5cf1f471f3438796fc634650b31d7fcde01d444c309aeb28b92e3a8"
 dependencies = [
  "log",
  "pest",
@@ -5814,8 +5814,7 @@ dependencies = [
 name = "template_handlebars"
 version = "1.0.0"
 dependencies = [
- "actix-http 2.2.2",
- "actix-web 3.3.3",
+ "actix-web 4.0.0-beta.21",
  "handlebars",
  "serde_json",
 ]

--- a/template_engines/handlebars/Cargo.toml
+++ b/template_engines/handlebars/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Alexandru Tiniuc <tiniuc.alexandru@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-actix-http = "2"
-actix-web = "3"
-handlebars = { version = "3.0.0", features = ["dir_source"] }
+actix-web = "4.0.0-beta.21"
+handlebars = { version = "4.2.1", features = ["dir_source"] }
 serde_json = "1.0"

--- a/template_engines/handlebars/src/main.rs
+++ b/template_engines/handlebars/src/main.rs
@@ -1,17 +1,11 @@
-#[macro_use]
-extern crate actix_web;
-
-#[macro_use]
-extern crate serde_json;
-
-use actix_http::{body::Body, Response};
+use actix_web::body::{BoxBody};
 use actix_web::dev::ServiceResponse;
+use actix_web::http::header::ContentType;
 use actix_web::http::StatusCode;
-use actix_web::middleware::errhandlers::{ErrorHandlerResponse, ErrorHandlers};
-use actix_web::{web, App, HttpResponse, HttpServer, Result};
-
+use actix_web::middleware::{ErrorHandlerResponse, ErrorHandlers};
+use actix_web::{get, web, App, HttpResponse, HttpServer, Result};
 use handlebars::Handlebars;
-
+use serde_json::json;
 use std::io;
 
 // Macro documentation can be found in the actix_web_codegen crate
@@ -28,8 +22,9 @@ async fn index(hb: web::Data<Handlebars<'_>>) -> HttpResponse {
 #[get("/{user}/{data}")]
 async fn user(
     hb: web::Data<Handlebars<'_>>,
-    web::Path(info): web::Path<(String, String)>,
+    path: web::Path<(String, String)>,
 ) -> HttpResponse {
+    let info = path.into_inner();
     let data = json!({
         "user": info.0,
         "data": info.1
@@ -63,27 +58,31 @@ async fn main() -> io::Result<()> {
 }
 
 // Custom error handlers, to return HTML responses when an error occurs.
-fn error_handlers() -> ErrorHandlers<Body> {
+fn error_handlers() -> ErrorHandlers<BoxBody> {
     ErrorHandlers::new().handler(StatusCode::NOT_FOUND, not_found)
 }
 
 // Error handler for a 404 Page not found error.
-fn not_found<B>(res: ServiceResponse<B>) -> Result<ErrorHandlerResponse<B>> {
+fn not_found<B>(res: ServiceResponse<B>) -> Result<ErrorHandlerResponse<BoxBody>> {
     let response = get_error_response(&res, "Page not found");
-    Ok(ErrorHandlerResponse::Response(
-        res.into_response(response.into_body()),
-    ))
+    Ok(ErrorHandlerResponse::Response(ServiceResponse::new(
+        res.into_parts().0,
+        response.map_into_left_body(),
+    )))
 }
 
 // Generic error handler.
-fn get_error_response<B>(res: &ServiceResponse<B>, error: &str) -> Response<Body> {
+fn get_error_response<B>(
+    res: &ServiceResponse<B>,
+    error: &str,
+) -> HttpResponse<BoxBody> {
     let request = res.request();
 
     // Provide a fallback to a simple plain text response in case an error occurs during the
     // rendering of the error page.
     let fallback = |e: &str| {
-        Response::build(res.status())
-            .content_type("text/plain")
+        HttpResponse::build(res.status())
+            .content_type(ContentType::plaintext())
             .body(e.to_string())
     };
 
@@ -99,12 +98,12 @@ fn get_error_response<B>(res: &ServiceResponse<B>, error: &str) -> Response<Body
             let body = hb.render("error", &data);
 
             match body {
-                Ok(body) => Response::build(res.status())
-                    .content_type("text/html")
+                Ok(body) => HttpResponse::build(res.status())
+                    .content_type(ContentType::html())
                     .body(body),
-                Err(_) => fallback(error),
+                Err(_) => fallback(error).into(),
             }
         }
-        None => fallback(error),
+        None => fallback(error).into(),
     }
 }

--- a/template_engines/handlebars/src/main.rs
+++ b/template_engines/handlebars/src/main.rs
@@ -1,4 +1,4 @@
-use actix_web::body::{BoxBody};
+use actix_web::body::BoxBody;
 use actix_web::dev::ServiceResponse;
 use actix_web::http::header::ContentType;
 use actix_web::http::StatusCode;


### PR DESCRIPTION
The `EitherBody` requirement on error handlers drove me a bit crazy.