### PR TITLE
Updated security/awc_https to v4.

### DIFF
--- a/security/awc_https/Cargo.toml
+++ b/security/awc_https/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["dowwie <dkcdkg@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-actix-web = { version = "4.0.0-beta.21", features = ["openssl"] }
-reqwest = "0.11.9"
+actix-web = "4.0.0-beta.21"
+awc = {version = "3.0.0-beta.19", features = ["openssl"]}
+openssl = "0.10.38"

--- a/security/awc_https/Cargo.toml
+++ b/security/awc_https/Cargo.toml
@@ -2,8 +2,8 @@
 name = "awc_https"
 version = "0.1.0"
 authors = ["dowwie <dkcdkg@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-actix-web = { version = "3", features = ["openssl"] }
-openssl = "0.10.28"
+actix-web = { version = "4.0.0-beta.21", features = ["openssl"] }
+reqwest = "0.11.9"

--- a/security/awc_https/README.md
+++ b/security/awc_https/README.md
@@ -3,7 +3,7 @@ for https related communication.  As of actix-web 2.0.0, one must be very
 careful about setting up https communication.  **You could use the default 
 awc api without configuring ssl but performance will be severely diminished**.
 
-This example downloads a 10MB image from wikipedia.
+This example downloads a 1MB image from wikipedia.
 
 To run:
 > curl http://localhost:3000 -o image.jpg

--- a/security/awc_https/src/main.rs
+++ b/security/awc_https/src/main.rs
@@ -1,7 +1,13 @@
 use actix_web::{web, App, HttpRequest, HttpResponse, HttpServer};
+use awc::{Client, Connector};
+use openssl::ssl::{SslConnector, SslMethod};
 
 async fn index(_req: HttpRequest) -> HttpResponse {
-    let client = reqwest::Client::new();
+    let builder = SslConnector::builder(SslMethod::tls()).unwrap();
+
+    let client = Client::builder()
+        .connector(Connector::new().openssl(builder.build()))
+        .finish();
 
     let now = std::time::Instant::now();
     let payload =
@@ -10,7 +16,8 @@ async fn index(_req: HttpRequest) -> HttpResponse {
         .send()
         .await
         .unwrap()
-        .bytes()
+        .body()
+        .limit(20_000_000)  // sets max allowable payload size
         .await
         .unwrap();
 

--- a/security/awc_https/src/main.rs
+++ b/security/awc_https/src/main.rs
@@ -1,25 +1,16 @@
-use actix_web::{
-    client::{Client, Connector},
-    web, App, HttpRequest, HttpResponse, HttpServer,
-};
-use openssl::ssl::{SslConnector, SslMethod};
+use actix_web::{web, App, HttpRequest, HttpResponse, HttpServer};
 
 async fn index(_req: HttpRequest) -> HttpResponse {
-    let builder = SslConnector::builder(SslMethod::tls()).unwrap();
-
-    let client = Client::builder()
-        .connector(Connector::new().ssl(builder.build()).finish())
-        .finish();
+    let client = reqwest::Client::new();
 
     let now = std::time::Instant::now();
     let payload =
         client
-        .get("https://upload.wikimedia.org/wikipedia/commons/f/ff/Pizigani_1367_Chart_10MB.jpg")
+        .get("https://upload.wikimedia.org/wikipedia/commons/b/b9/Pizigani_1367_Chart_1MB.jpg")
         .send()
         .await
         .unwrap()
-        .body()
-        .limit(20_000_000)  // sets max allowable payload size
+        .bytes()
         .await
         .unwrap();
 


### PR DESCRIPTION
As `actix_web::client` is no more in v4 I added `reqwest` to make Http requests. I removed `openssl` as a dependancy as `reqwest::Client` implements tls by default.