### PR TITLE
Don't use mutex directly in async code

### DIFF
--- a/server-sent-events/src/broadcast.rs
+++ b/server-sent-events/src/broadcast.rs
@@ -11,7 +11,7 @@ use actix_web::{
 };
 use futures_util::Stream;
 use parking_lot::Mutex;
-use tokio::sync::mpsc::{channel, Sender, Receiver};
+use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 pub struct Broadcaster {
     inner: Mutex<BroadcasterInner>,

--- a/server-sent-events/src/main.rs
+++ b/server-sent-events/src/main.rs
@@ -4,7 +4,6 @@ use actix_web::{
     web::{self, Data, Path},
     App, HttpResponse, HttpServer, Responder,
 };
-use parking_lot::Mutex;
 
 mod broadcast;
 use broadcast::Broadcaster;
@@ -38,15 +37,15 @@ async fn index() -> impl Responder {
         .body(index_html)
 }
 
-async fn new_client(broadcaster: Data<Mutex<Broadcaster>>) -> impl Responder {
-    let rx = broadcaster.lock().new_client();
+async fn new_client(broadcaster: Data<Broadcaster>) -> impl Responder {
+    let rx = broadcaster.new_client();
 
     HttpResponse::Ok()
         .append_header((header::CONTENT_TYPE, "text/event-stream"))
         .streaming(rx)
 }
 
-async fn broadcast(msg: Path<String>, broadcaster: Data<Mutex<Broadcaster>>) -> impl Responder {
-    broadcaster.lock().send(&msg.into_inner());
+async fn broadcast(msg: Path<String>, broadcaster: Data<Broadcaster>) -> impl Responder {
+    broadcaster.send(&msg.into_inner());
     HttpResponse::Ok().body("msg sent")
 }


### PR DESCRIPTION
You generally don't want to lock a `Mutex` directly in async code, since that easily results in hard-to-read errors about Send, or worse, deadlocks. This changes an example so that the mutex is instead locked in non-async functions, which can then be called from the async code.

It also removes some unnecessary uses of the stream wrappers in `tokio-stream`.