### PR TITLE
fix typo for websockets/chat-tcp/client.rs

### DIFF
--- a/websockets/chat-tcp/src/client.rs
+++ b/websockets/chat-tcp/src/client.rs
@@ -49,7 +49,7 @@ async fn main() {
                     Ok(codec::ChatResponse::Rooms(rooms)) => {
                         println!("!!! Available rooms:");
                         for room in rooms {
-                        println!("{}", room);
+                            println!("{}", room);
                         }
                     }
 


### PR DESCRIPTION
I found the indentation was broken and fixed it.