### PR TITLE
Fixes #537, Update dependencies for databases/postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
  "lazy_static",
  "log",
  "openssl",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "time 0.1.43",
  "ureq",
@@ -209,7 +209,7 @@ dependencies = [
  "futures-core",
  "http",
  "log",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "slab",
@@ -227,7 +227,7 @@ dependencies = [
  "actix-utils",
  "actix-web",
  "futures-util",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "time 0.3.7",
 ]
@@ -291,7 +291,7 @@ dependencies = [
  "rand 0.8.5",
  "redis",
  "redis-async",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "time 0.3.7",
  "tokio 1.17.0",
@@ -309,7 +309,7 @@ dependencies = [
  "http",
  "log",
  "regex",
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
@@ -364,7 +364,7 @@ dependencies = [
  "derive_more",
  "futures-util",
  "log",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "time 0.3.7",
 ]
@@ -386,7 +386,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "log",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 1.17.0",
@@ -455,7 +455,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite 0.2.8",
  "regex",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "smallvec",
@@ -500,7 +500,7 @@ dependencies = [
  "actix-cors",
  "actix-web",
  "env_logger",
- "serde 1.0.136",
+ "serde",
  "serde_json",
 ]
 
@@ -527,7 +527,7 @@ dependencies = [
  "mime",
  "once_cell",
  "pin-project-lite 0.2.8",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 1.17.0",
@@ -559,7 +559,7 @@ dependencies = [
  "mime",
  "once_cell",
  "pin-project-lite 0.2.8",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "subtle",
@@ -592,7 +592,7 @@ dependencies = [
  "mime",
  "once_cell",
  "pin-project-lite 0.2.8",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "subtle",
@@ -621,7 +621,7 @@ dependencies = [
  "futures-util",
  "log",
  "redis-async",
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
@@ -742,12 +742,6 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
@@ -802,12 +796,12 @@ dependencies = [
  "humansize",
  "mime",
  "mime_guess",
- "nom 7.1.1",
- "num-traits 0.2.14",
+ "nom",
+ "num-traits",
  "percent-encoding",
  "proc-macro2",
  "quote",
- "serde 1.0.136",
+ "serde",
  "syn",
  "toml",
 ]
@@ -842,11 +836,11 @@ dependencies = [
  "indexmap",
  "mime",
  "multer",
- "num-traits 0.2.14",
+ "num-traits",
  "once_cell",
  "pin-project-lite 0.2.8",
  "regex",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "static_assertions 1.1.0",
  "tempfile",
@@ -912,7 +906,7 @@ dependencies = [
  "async-graphql-value",
  "pest",
  "pest_derive",
- "serde 1.0.136",
+ "serde",
  "serde_json",
 ]
 
@@ -924,7 +918,7 @@ checksum = "d435e9006dc82138249a64969d820a8d344357ded2075ca93d764d91f26999c9"
 dependencies = [
  "bytes 1.1.0",
  "indexmap",
- "serde 1.0.136",
+ "serde",
  "serde_json",
 ]
 
@@ -981,7 +975,7 @@ dependencies = [
  "r2d2",
  "r2d2_sqlite",
  "rusqlite",
- "serde 1.0.136",
+ "serde",
  "serde_json",
 ]
 
@@ -994,7 +988,7 @@ dependencies = [
  "deadpool-postgres",
  "derive_more",
  "dotenv",
- "serde 1.0.136",
+ "serde",
  "tokio-pg-mapper",
  "tokio-pg-mapper-derive",
  "tokio-postgres",
@@ -1006,7 +1000,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616896e05fc0e2649463a93a15183c6a16bf03413a7af88ef1285ddedfa9cda5"
 dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -1056,7 +1050,7 @@ dependencies = [
  "pin-project-lite 0.2.8",
  "rand 0.8.5",
  "rustls 0.20.4",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 1.17.0",
@@ -1138,8 +1132,8 @@ checksum = "1374191e2dd25f9ae02e3aa95041ed5d747fc77b3c102b49fe2dd9a8117a6244"
 dependencies = [
  "num-bigint",
  "num-integer",
- "num-traits 0.2.14",
- "serde 1.0.136",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1231,7 +1225,7 @@ dependencies = [
  "lazy_static",
  "linked-hash-map",
  "rand 0.7.3",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "uuid",
 ]
@@ -1249,7 +1243,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "rand 0.8.5",
- "serde 1.0.136",
+ "serde",
  "serde_bytes",
  "serde_json",
  "uuid",
@@ -1264,7 +1258,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
@@ -1322,7 +1316,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 dependencies = [
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
@@ -1352,7 +1346,7 @@ dependencies = [
  "regex",
  "rhai",
  "ritelinked",
- "serde 1.0.136",
+ "serde",
  "thiserror",
  "tokio 1.17.0",
 ]
@@ -1386,8 +1380,8 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits 0.2.14",
- "serde 1.0.136",
+ "num-traits",
+ "serde",
  "time 0.1.43",
  "winapi 0.3.9",
 ]
@@ -1508,15 +1502,18 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.11.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
+checksum = "3ea917b74b6edfb5024e3b55d3c8f710b5f4ed92646429601a42e96f0812b31b"
 dependencies = [
+ "async-trait",
+ "json5",
  "lazy_static",
- "nom 5.1.2",
+ "nom",
+ "pathdiff",
+ "ron",
  "rust-ini",
- "serde 1.0.136",
- "serde-hjson",
+ "serde",
  "serde_json",
  "toml",
  "yaml-rust",
@@ -1599,7 +1596,7 @@ dependencies = [
  "idna",
  "log",
  "publicsuffix",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "time 0.2.27",
  "url",
@@ -1714,7 +1711,7 @@ dependencies = [
  "csv-core",
  "itoa 0.4.8",
  "ryu",
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
@@ -1785,19 +1782,19 @@ dependencies = [
  "async-trait",
  "deadpool-runtime",
  "num_cpus",
- "serde 1.0.136",
+ "serde",
  "tokio 1.17.0",
 ]
 
 [[package]]
 name = "deadpool-postgres"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ff1451a33b8b31b15eedcf5401dbbb28606caed4fa94d20487eb3fac2ebd04"
+checksum = "c668a58063c6331e3437e3146970943ad82b1b36169fd979bb2645ac2088209a"
 dependencies = [
  "deadpool",
  "log",
- "serde 1.0.136",
+ "serde",
  "tokio 1.17.0",
  "tokio-postgres",
 ]
@@ -1935,6 +1932,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
 name = "docker_sample"
 version = "1.0.0"
 dependencies = [
@@ -1961,7 +1964,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 dependencies = [
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
@@ -2142,7 +2145,7 @@ name = "form-example"
 version = "1.0.0"
 dependencies = [
  "actix-web",
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
@@ -2439,7 +2442,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "quick-error 2.0.1",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "walkdir",
 ]
@@ -2454,12 +2457,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -2750,8 +2762,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
- "hashbrown",
- "serde 1.0.136",
+ "hashbrown 0.11.2",
+ "serde",
 ]
 
 [[package]]
@@ -2862,7 +2874,7 @@ dependencies = [
  "futures-util",
  "json",
  "log",
- "serde 1.0.136",
+ "serde",
  "serde_json",
 ]
 
@@ -2875,10 +2887,21 @@ dependencies = [
  "env_logger",
  "futures-util",
  "log",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "validator",
  "validator_derive",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -2888,7 +2911,7 @@ dependencies = [
  "actix-web",
  "env_logger",
  "log",
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
@@ -2898,7 +2921,7 @@ dependencies = [
  "actix-web",
  "env_logger",
  "log",
- "serde 1.0.136",
+ "serde",
  "serde_json",
 ]
 
@@ -2911,7 +2934,7 @@ dependencies = [
  "env_logger",
  "futures-util",
  "log",
- "serde 1.0.136",
+ "serde",
  "serde_json",
 ]
 
@@ -2930,7 +2953,7 @@ dependencies = [
  "graphql-parser",
  "indexmap",
  "juniper_codegen",
- "serde 1.0.136",
+ "serde",
  "smartstring",
  "static_assertions 1.1.0",
  "url",
@@ -2951,7 +2974,7 @@ dependencies = [
  "mysql",
  "r2d2",
  "r2d2_mysql",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "uuid",
 ]
@@ -2966,7 +2989,7 @@ dependencies = [
  "env_logger",
  "juniper",
  "log",
- "serde 1.0.136",
+ "serde",
  "serde_json",
 ]
 
@@ -3011,7 +3034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b33373fcaba01f90be959f0a1028098d388663c187bbf373d990c12e747788bd"
 dependencies = [
  "cfg-if 0.1.10",
- "lexical-core 0.6.8",
+ "lexical-core",
  "rustc_version 0.2.3",
 ]
 
@@ -3027,19 +3050,6 @@ dependencies = [
  "rustc_version 0.2.3",
  "ryu",
  "static_assertions 0.3.4",
-]
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec 0.5.2",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions 1.1.0",
 ]
 
 [[package]]
@@ -3329,7 +3339,7 @@ version = "1.0.0"
 dependencies = [
  "actix-web",
  "mongodb 2.1.0",
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
@@ -3358,7 +3368,7 @@ dependencies = [
  "rand 0.8.5",
  "rustls 0.19.1",
  "rustls-pemfile 0.2.1",
- "serde 1.0.136",
+ "serde",
  "serde_bytes",
  "serde_with",
  "sha-1 0.9.8",
@@ -3422,7 +3432,7 @@ dependencies = [
  "rusoto_core",
  "rusoto_s3",
  "sanitize-filename",
- "serde 1.0.136",
+ "serde",
  "serde_json",
 ]
 
@@ -3442,7 +3452,7 @@ dependencies = [
  "net2",
  "nix",
  "percent-encoding",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "twox-hash",
  "url",
@@ -3466,11 +3476,11 @@ dependencies = [
  "lazy_static",
  "lexical",
  "num-bigint",
- "num-traits 0.2.14",
+ "num-traits",
  "rand 0.7.3",
  "regex",
  "rust_decimal",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "sha1",
  "sha2 0.8.2",
@@ -3512,7 +3522,7 @@ version = "1.0.0"
 dependencies = [
  "actix-web",
  "env_logger",
- "serde 1.0.136",
+ "serde",
  "serde_json",
 ]
 
@@ -3554,17 +3564,6 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "lexical-core 0.7.6",
- "memchr",
- "version_check",
-]
-
-[[package]]
-name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
@@ -3590,7 +3589,7 @@ checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -3600,16 +3599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits 0.2.14",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -3724,6 +3714,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.12.1",
+]
+
+[[package]]
 name = "os_info"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3804,6 +3804,12 @@ name = "paste"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pbkdf2"
@@ -3998,9 +4004,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ec03bce71f18b4a27c4c64c6ba2ddf74686d69b91d8714fb32ead3adaed713"
+checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
@@ -4016,9 +4022,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04619f94ba0cc80999f4fc7073607cb825bc739a883cb6d20900fc5e009d6b0d"
+checksum = "ebd6e8b7189a73169290e89bd24c771071f1012d8fe6f738f5226531f0b03d89"
 dependencies = [
  "bytes 1.1.0",
  "fallible-iterator",
@@ -4339,7 +4345,7 @@ dependencies = [
  "actix-web",
  "env_logger",
  "log",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "time 0.3.7",
 ]
@@ -4430,7 +4436,7 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.8",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 0.2.25",
@@ -4466,7 +4472,7 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.8",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 1.17.0",
@@ -4496,9 +4502,9 @@ checksum = "49c94fda0280985896ed6d8bf0b43bbb5a7f0e39ccc8728ac907ddb4f06dae94"
 dependencies = [
  "ahash",
  "instant",
- "num-traits 0.2.14",
+ "num-traits",
  "rhai_codegen",
- "serde 1.0.136",
+ "serde",
  "smallvec",
  "smartstring",
 ]
@@ -4536,7 +4542,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98f2771d255fd99f0294f13249fecd0cae6e074f86b4197ec1f1689d537b44d3"
 dependencies = [
  "ahash",
- "hashbrown",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "ron"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
+dependencies = [
+ "base64 0.13.0",
+ "bitflags",
+ "serde",
 ]
 
 [[package]]
@@ -4567,7 +4584,7 @@ dependencies = [
  "rusoto_credential",
  "rusoto_signature",
  "rustc_version 0.4.0",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "tokio 1.17.0",
  "xml-rs",
@@ -4584,7 +4601,7 @@ dependencies = [
  "dirs-next",
  "futures",
  "hyper 0.14.17",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "shlex",
  "tokio 1.17.0",
@@ -4625,7 +4642,7 @@ dependencies = [
  "pin-project-lite 0.2.8",
  "rusoto_credential",
  "rustc_version 0.4.0",
- "serde 1.0.136",
+ "serde",
  "sha2 0.9.9",
  "tokio 1.17.0",
 ]
@@ -4659,9 +4676,13 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.13.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ordered-multimap",
+]
 
 [[package]]
 name = "rust_decimal"
@@ -4670,8 +4691,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d37baa70cf8662d2ba1c1868c5983dda16ef32b105cce41fb5c47e72936a90b3"
 dependencies = [
  "arrayvec 0.7.2",
- "num-traits 0.2.14",
- "serde 1.0.136",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -4925,29 +4946,11 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "0.8.23"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-
-[[package]]
-name = "serde"
-version = "1.0.136"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-hjson"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
-dependencies = [
- "lazy_static",
- "num-traits 0.1.43",
- "regex",
- "serde 0.8.23",
 ]
 
 [[package]]
@@ -4956,14 +4959,14 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4979,7 +4982,7 @@ dependencies = [
  "indexmap",
  "itoa 1.0.1",
  "ryu",
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
@@ -4991,7 +4994,7 @@ dependencies = [
  "form_urlencoded",
  "itoa 1.0.1",
  "ryu",
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
@@ -5001,7 +5004,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec1e6ec4d8950e5b1e894eac0d360742f3b1407a6078a604a731c4b3f49cefbc"
 dependencies = [
  "rustversion",
- "serde 1.0.136",
+ "serde",
  "serde_with_macros",
 ]
 
@@ -5156,7 +5159,7 @@ dependencies = [
  "lazy_static",
  "r2d2",
  "rust-argon2",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "sparkpost",
  "time 0.3.7",
@@ -5228,7 +5231,7 @@ checksum = "ba54017cf417e62d64260167de6b8d578f99a248225d3f9fd3396db1ab9e7fbc"
 dependencies = [
  "chrono",
  "reqwest 0.10.10",
- "serde 1.0.136",
+ "serde",
  "serde_derive",
  "serde_json",
 ]
@@ -5255,7 +5258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4b7922be017ee70900be125523f38bdd644f4f06a1b16e8fa5a8ee8c34bffd4"
 dependencies = [
  "itertools",
- "nom 7.1.1",
+ "nom",
  "unicode_categories",
 ]
 
@@ -5301,7 +5304,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rustls 0.19.1",
- "serde 1.0.136",
+ "serde",
  "sha2 0.9.9",
  "smallvec",
  "sqlformat",
@@ -5327,7 +5330,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "sha2 0.9.9",
  "sqlx-core",
@@ -5408,7 +5411,7 @@ checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde 1.0.136",
+ "serde",
  "serde_derive",
  "syn",
 ]
@@ -5422,7 +5425,7 @@ dependencies = [
  "base-x",
  "proc-macro2",
  "quote",
- "serde 1.0.136",
+ "serde",
  "serde_derive",
  "serde_json",
  "sha1",
@@ -5446,7 +5449,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "phf_shared 0.10.0",
  "precomputed-hash",
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
@@ -5485,9 +5488,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.88"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd69e719f31e88618baa1eaa6ee2de5c9a1c004f1e9ecdb58e8352a13f20a01"
+checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5618,7 +5621,7 @@ dependencies = [
  "pest_derive",
  "rand 0.8.5",
  "regex",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "slug",
  "unic-segment",
@@ -5740,7 +5743,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.136",
+ "serde",
  "serde_json",
 ]
 
@@ -5769,7 +5772,7 @@ dependencies = [
  "dotenv",
  "env_logger",
  "log",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "sqlx",
  "tera",
@@ -5868,9 +5871,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6c8b33df661b548dcd8f9bf87debb8c56c05657ed291122e1188698c2ece95"
+checksum = "19c88a47a23c5d2dc9ecd28fb38fba5fc7e5ddc1fe64488ec145076b0c71c8ae"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5878,7 +5881,7 @@ dependencies = [
  "fallible-iterator",
  "futures",
  "log",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "percent-encoding",
  "phf 0.10.1",
  "pin-project-lite 0.2.8",
@@ -5886,7 +5889,7 @@ dependencies = [
  "postgres-types",
  "socket2 0.4.4",
  "tokio 1.17.0",
- "tokio-util 0.6.9",
+ "tokio-util 0.7.0",
 ]
 
 [[package]]
@@ -5980,7 +5983,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
@@ -6305,7 +6308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.5",
- "serde 1.0.136",
+ "serde",
 ]
 
 [[package]]
@@ -6356,7 +6359,7 @@ dependencies = [
  "idna",
  "lazy_static",
  "regex",
- "serde 1.0.136",
+ "serde",
  "serde_derive",
  "serde_json",
  "url",
@@ -6453,7 +6456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "wasm-bindgen-macro",
 ]
@@ -6616,7 +6619,7 @@ dependencies = [
  "env_logger",
  "log",
  "rand 0.8.5",
- "serde 1.0.136",
+ "serde",
  "serde_json",
 ]
 
@@ -6635,7 +6638,7 @@ dependencies = [
  "futures-util",
  "log",
  "rand 0.8.5",
- "serde 1.0.136",
+ "serde",
  "serde_json",
  "tokio 1.17.0",
  "tokio-stream",
@@ -6861,7 +6864,7 @@ dependencies = [
  "itoa 0.4.8",
  "prettyplease",
  "ryu",
- "serde 1.0.136",
+ "serde",
  "syn",
  "toml",
  "v_htmlescape",
@@ -6908,7 +6911,7 @@ dependencies = [
  "derive_more",
  "proc-macro2",
  "quote",
- "serde 1.0.136",
+ "serde",
  "syn",
  "unicode-xid",
  "yarte_helpers",

--- a/databases/postgres/Cargo.toml
+++ b/databases/postgres/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4"
-config = "0.11.0"
-deadpool-postgres = { version = "0.10.1", features = ["serde"] }
-derive_more = "0.99.2"
+config = "0.13.1"
+deadpool-postgres = { version = "0.10.2", features = ["serde"] }
+derive_more = "0.99.17"
 dotenv = "0.15.0"
-serde = { version = "1.0.104", features = ["derive"] }
+serde = { version = "1.0.137", features = ["derive"] }
 tokio-pg-mapper = "0.2.0"
 tokio-pg-mapper-derive = "0.2.0"
-tokio-postgres = "0.7.5"
+tokio-postgres = "0.7.6"


### PR DESCRIPTION
Fix config code to account for breaking changes when updating.

 Note, I updated to most recent .13.1, not .12 as per #537 

I followed this example code for the config changes:
https://github.com/mehcode/config-rs/blob/master/examples/env-list/main.rs

I ran the server and ran the example request, and saw no errors.