### PR TITLE
Replace all unwraps in hello-world example with ? operator

### DIFF
--- a/basics/hello-world/src/main.rs
+++ b/basics/hello-world/src/main.rs
@@ -35,12 +35,12 @@ mod tests {
         let app = test::init_service(app).await;
 
         let req = test::TestRequest::get().uri("/").to_request();
-        let resp = app.call(req).await.unwrap();
+        let resp = app.call(req).await?;
 
         assert_eq!(resp.status(), http::StatusCode::OK);
 
         let response_body = resp.into_body();
-        assert_eq!(to_bytes(response_body).await.unwrap(), r##"Hello world!"##);
+        assert_eq!(to_bytes(response_body).await?, r##"Hello world!"##);
 
         Ok(())
     }


### PR DESCRIPTION
Hello. This is a pretty insignificant change, but I noticed that the hello-world example uses 2 unwraps in the tests even though it returns a `Result`, so I thought that it should use `?` instead of `.unwrap()`. This PR changes 2 lines of code in the `test_index` test.