### PR TITLE
Fix bug in cookie-auth example where secret is too short

### DIFF
--- a/auth/cookie-auth/src/main.rs
+++ b/auth/cookie-auth/src/main.rs
@@ -33,16 +33,16 @@ async fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "actix_web=info");
     env_logger::init();
 
-    // Generate a random 32 byte key. Note that it is important to use a unique
-    // private key for every project. Anyone with access to the key can generate
-    // authentication cookies for any user!
-    let private_key = rand::thread_rng().gen::<[u8; 32]>();
+    /// Generate a random secret key. Note that it is important to use a unique
+    /// secret key for every project. Anyone with access to the key can generate
+    /// authentication cookies for any user!
+    let secret_key = Key::generate();
 
     HttpServer::new(move || {
         App::new()
             .wrap(IdentityMiddleware::default())
             .wrap(
-                SessionMiddleware::builder(CookieSessionStore::default(), Key::from(&private_key))
+                SessionMiddleware::builder(CookieSessionStore::default(), secret_key)
                     .cookie_name("auth-example".to_owned())
                     .cookie_secure(false)
                     .build(),

--- a/auth/cookie-auth/src/main.rs
+++ b/auth/cookie-auth/src/main.rs
@@ -33,9 +33,9 @@ async fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "actix_web=info");
     env_logger::init();
 
-    /// Generate a random secret key. Note that it is important to use a unique
-    /// secret key for every project. Anyone with access to the key can generate
-    /// authentication cookies for any user!
+    // Generate a random secret key. Note that it is important to use a unique
+    // secret key for every project. Anyone with access to the key can generate
+    // authentication cookies for any user!
     let secret_key = Key::generate();
 
     HttpServer::new(move || {


### PR DESCRIPTION
Running the example as it is currently results in a panic at startup:

```
panicked at 'called `Result::unwrap()` on an `Err` value: TooShort(32)', ~/.cargo/registry/src/github.com-1ecc6299db9ec823/cookie-0.16.1/src/secure/key.rs:63:28
```

This is because the example creates a secret key of 32 bytes, but the required size is `COMBINED_KEY_LENGTH` which is 64 bytes.

Because the docs for `SessionMiddleware` refer to this as a secret key, and because `private key` usually refers to a TLS key in HTTP contexts, I also changed the comment and variable name.