### PR TITLE
add content_type for basic example response body to decode utf-8 correctly

### DIFF
--- a/basics/basics/src/main.rs
+++ b/basics/basics/src/main.rs
@@ -58,11 +58,13 @@ async fn default_handler(req_method: Method) -> Result<impl Responder> {
 async fn response_body(path: web::Path<String>) -> HttpResponse {
     let name = path.into_inner();
 
-    HttpResponse::Ok().streaming(stream! {
-        yield Ok::<_, Infallible>(web::Bytes::from("Hello "));
-        yield Ok::<_, Infallible>(web::Bytes::from(name));
-        yield Ok::<_, Infallible>(web::Bytes::from("!"));
-    })
+    HttpResponse::Ok()
+        .content_type(ContentType::plaintext())
+        .streaming(stream! {
+            yield Ok::<_, Infallible>(web::Bytes::from("Hello "));
+            yield Ok::<_, Infallible>(web::Bytes::from(name));
+            yield Ok::<_, Infallible>(web::Bytes::from("!"));
+        })
 }
 
 /// handler with path parameters like `/user/{name}/`


### PR DESCRIPTION
The code for service "/async-body/{name}" will not render non ascii input correctly, because the HTTP response header is not set to use charset UTF-8. 

Test on localhost:
Before:
<img width="1083" alt="Screenshot 2022-11-21 at 9 45 14 PM" src="https://user-images.githubusercontent.com/6826647/203070650-57a5c23e-3280-4d21-b85e-f6376f92f661.png">

After:
<img width="1089" alt="Screenshot 2022-11-21 at 9 44 08 PM" src="https://user-images.githubusercontent.com/6826647/203070694-58ecdbd9-f556-40eb-be5e-e0d5d486accd.png">
