### PR TITLE
Add SeaORM in examples/databases.

### DIFF
--- a/databases/sea-orm/README.md
+++ b/databases/sea-orm/README.md
@@ -1,0 +1,5 @@
+# [SeaORM](https://github.com/SeaQL/sea-orm) 
+
+You can find the SeaORM with Actix 4 example in the [sea-orm/examples/actix_example/](https://github.com/SeaQL/sea-orm/tree/master/examples/actix_example) 
+  
+And with the Actix 3 here:  [sea-orm/examples/actix3_example/](https://github.com/SeaQL/sea-orm/tree/master/examples/actix3_example)


### PR DESCRIPTION
In my research, 
I found that SeaORM (https://github.com/SeaQL/sea-orm) supports actix (v4 and v3) 

I thought it might be appropriate for our repo.

![CleanShot 2022-11-22 at 17 57 42](https://user-images.githubusercontent.com/11187239/203284277-e77adf06-ed12-4643-af16-eb92294a98f5.png)

