### PR TITLE
Fix incorrect spelling of file setup_db.sh

### DIFF
--- a/databases/sqlite/db/README.md
+++ b/databases/sqlite/db/README.md
@@ -2,4 +2,4 @@ This directory includes weather information obtained from NOAA for NYC Central P
 
 # Setup Instructions
 
-Set up a sqlite3 database by executing the setup_db.sh file: `bash sqlite_db.sh`
+Set up a sqlite3 database by executing the setup_db.sh file: `bash setup_db.sh`


### PR DESCRIPTION
No file named sqlite_db.sh exists in the folder, so I assume the correct one would be setup_db.sh.