### PR TITLE
https-tls: typo - correct logged URIs to use https

### DIFF
--- a/https-tls/openssl-auto-le/src/main.rs
+++ b/https-tls/openssl-auto-le/src/main.rs
@@ -173,7 +173,7 @@ async fn main() -> anyhow::Result<()> {
     // Storing pkey_der, cert_der and intermediate_cert somewhere
     // (in order to avoid unnecessarily regeneration of TLS/SSL) is recommended
 
-    log::info!("starting HTTP server at http://localhost:443");
+    log::info!("starting HTTP server at https://localhost:443");
 
     // Start HTTP server!
     let srv = HttpServer::new(|| App::new().route("/", web::get().to(index)))

--- a/https-tls/openssl/src/main.rs
+++ b/https-tls/openssl/src/main.rs
@@ -16,7 +16,7 @@ async fn main() -> io::Result<()> {
     std::env::set_var("RUST_LOG", "actix_web=debug");
     env_logger::init();
 
-    println!("Started http server: 127.0.0.1:8443");
+    println!("Started http server: https://127.0.0.1:8443");
 
     // load TLS keys
     let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls()).unwrap();

--- a/https-tls/rustls-client-cert/src/main.rs
+++ b/https-tls/rustls-client-cert/src/main.rs
@@ -103,7 +103,7 @@ async fn main() -> std::io::Result<()> {
         .collect();
     let config = config.with_single_cert(cert_chain, keys.remove(0)).unwrap();
 
-    log::info!("starting HTTP server at http://localhost:8080 and http://localhost:8443");
+    log::info!("starting HTTP server at http://localhost:8080 and https://localhost:8443");
 
     HttpServer::new(|| App::new().default_service(web::to(route_whoami)))
         .on_connect(get_client_cert)

--- a/https-tls/rustls/src/main.rs
+++ b/https-tls/rustls/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> std::io::Result<()> {
 
     let config = load_rustls_config();
 
-    log::info!("starting HTTPS server at http://localhost:8443");
+    log::info!("starting HTTPS server at https://localhost:8443");
 
     HttpServer::new(|| {
         App::new()


### PR DESCRIPTION
When exploring the https-tls examples, I noticed that the URIs printed to screen were using the wrong protocol.

This PR corrects the protocol to use https, so that if you click on the link it works as expected.