### PR TITLE
change `curl -X post` to `curl -X POST`

### DIFF
--- a/server-sent-events/README.md
+++ b/server-sent-events/README.md
@@ -10,7 +10,7 @@ cargo run
 Open http://127.0.0.1:8080/ with a browser, then send events with another HTTP client:
 
 ```sh
-curl -X post 127.0.0.1:8080/broadcast/my_message
+curl -X POST 127.0.0.1:8080/broadcast/my_message
 ```
 
 _my_message_ should appear in the browser with a timestamp.


### PR DESCRIPTION
curl likes the request method to be all-caps; the request method isn't accepted otherwise.