### PR TITLE
fix server-sent-events/drain.js

### DIFF
--- a/server-sent-events/drain.js
+++ b/server-sent-events/drain.js
@@ -25,11 +25,10 @@ setInterval(() => {
       .on('error', () => {})
       .end()
   }
-}, 1)
+}, 0)
 
 setInterval(() => {
-  http
-    .post('http://127.0.0.1:8080/', () => print_status(true))
+  http.request({ ...query, path: '/' }, () => print_status(true))
     .setTimeout(100, () => print_status(false))
     .on('error', () => {})
 }, 20)


### PR DESCRIPTION
drain.js was failing to run in node 14, 16, and 18, with the following error:

```
/home/user/actix/examples/server-sent-events/drain.js:32
    .post('http://127.0.0.1:8080/', () => print_status(true))
     ^

TypeError: http.post is not a function
    at Timeout._onTimeout (/home/mclayton/projects/mwc/actix/examples/server-sent-events/drain.js:32:6)
    at listOnTimeout (node:internal/timers:569:17)
    at process.processTimers (node:internal/timers:512:7)
```

I replaced `http.post` with `http.request`.
