### PR TITLE
Fix Websockets/Chat: Prefixing Username to Messages Interferes with Server Commands

### DIFF
--- a/websockets/chat/client.py
+++ b/websockets/chat/client.py
@@ -41,7 +41,10 @@ async def start_client(url: str) -> None:
 
             # Exit with Ctrl+D
             while line := await asyncio.to_thread(sys.stdin.readline):
-                await ws.send_str(name + ": " + line)
+                if line.startswith("/"):
+                    await ws.send_str(line)
+                else:
+                    await ws.send_str(name + ": " + line)
 
             dispatch_task.cancel()
             with suppress(asyncio.CancelledError):


### PR DESCRIPTION
Hello,

This pull request addresses an issue with the Python client in the WebSocket chat example. The client prefixes the username and a colon to all messages before sending them to the server. This interferes with server commands like `/join`, `/list`, and `/name`.

Relevant code from the Python client (examples/websockets/chat/client.py):
```python
while line := await asyncio.to_thread(sys.stdin.readline):
    await ws.send_str(name + ": " + line)
```

Relevant code from the Rust session (examples/websockets/chat/src/session.rs):
```rust
ws::Message::Text(text) => {
    let m = text.trim();
    if m.starts_with('/') {
        let v: Vec<&str> = m.splitn(2, ' ').collect();
        // ...
    }
    // ...
}
```
The server expects commands to start with a `/`, but because the client prefixes the username to all messages, commands like `/join` are sent with a username: `joebloggs: /join room1`, which the server does not recognize as a command.

I've modified the Python client to not prefix the username to messages that start with `/`.

Please review this pull request and let me know if any changes are required.