### PR TITLE
fix python docs and added venv

### DIFF
--- a/websockets/chat/README.md
+++ b/websockets/chat/README.md
@@ -32,7 +32,9 @@ Use two tabs to set up a proper conversation.
 ## Python Client using aiohttp
 
 Client connects to server. Reads input from stdin and sends to server.
-Fetch the needed python libraries `pip3 install --requirements requirements.txt`
+Create a venv environment `python3 -m venv venv`
+Launch venv environment `source ./venv/bin/activate`
+Fetch the needed python libraries `pip3 install -r requirements.txt`
 Then start client as `./client.py`
 
 


### PR DESCRIPTION
I did just test this example. I realized that `pip3 install --requirements requirements.txt` and I suggest to always use a venv when using python to separate dependencies