### PR TITLE
Fix small issues in juniper-advanced example

### DIFF
--- a/graphql/juniper-advanced/mysql-schema.sql
+++ b/graphql/juniper-advanced/mysql-schema.sql
@@ -7,7 +7,7 @@
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
- SET NAMES utf8 ;
+ SET NAMES utf8mb4 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -21,7 +21,7 @@
 
 DROP TABLE IF EXISTS `product`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
- SET character_set_client = utf8 ;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `product` (
   `id` varchar(255) NOT NULL,
   `user_id` varchar(255) NOT NULL,
@@ -30,7 +30,7 @@ CREATE TABLE `product` (
   PRIMARY KEY (`id`),
   KEY `product_fk0` (`user_id`),
   CONSTRAINT `product_fk0` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
-) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
+) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -48,14 +48,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `user`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
- SET character_set_client = utf8 ;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `user` (
   `id` varchar(255) NOT NULL,
   `name` varchar(255) NOT NULL,
   `email` varchar(255) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `email` (`email`)
-) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
+) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/graphql/juniper-advanced/mysql-schema.sql
+++ b/graphql/juniper-advanced/mysql-schema.sql
@@ -7,7 +7,7 @@
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
- SET NAMES utf8mb4 ;
+ SET NAMES utf8 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -21,7 +21,7 @@
 
 DROP TABLE IF EXISTS `product`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
- SET character_set_client = utf8mb4 ;
+ SET character_set_client = utf8 ;
 CREATE TABLE `product` (
   `id` varchar(255) NOT NULL,
   `user_id` varchar(255) NOT NULL,
@@ -30,7 +30,7 @@ CREATE TABLE `product` (
   PRIMARY KEY (`id`),
   KEY `product_fk0` (`user_id`),
   CONSTRAINT `product_fk0` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
-) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -48,14 +48,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `user`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
- SET character_set_client = utf8mb4 ;
+ SET character_set_client = utf8 ;
 CREATE TABLE `user` (
   `id` varchar(255) NOT NULL,
   `name` varchar(255) NOT NULL,
   `email` varchar(255) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `email` (`email`)
-) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/graphql/juniper-advanced/src/schemas/root.rs
+++ b/graphql/juniper-advanced/src/schemas/root.rs
@@ -51,7 +51,7 @@ impl QueryRoot {
         Ok(User { id, name, email })
     }
 
-    #[graphql(description = "List of all users")]
+    #[graphql(description = "List of all products")]
     fn products(context: &Context) -> FieldResult<Vec<Product>> {
         let mut conn = context.db_pool.get().unwrap();
 
@@ -65,7 +65,7 @@ impl QueryRoot {
         Ok(products)
     }
 
-    #[graphql(description = "Get Single user reference by user ID")]
+    #[graphql(description = "Get Single product reference by product ID")]
     fn product(context: &Context, id: String) -> FieldResult<Product> {
         let mut conn = context.db_pool.get().unwrap();
         let product: Result<Option<Row>, DBError> =


### PR DESCRIPTION
This PR addresses two issues I ran into while running the "juniper-advanced" example:

- Encoding error in mysql-schema.sql
  - I'm admittedly not sure how broadly useful this is, as I don't regularly use mysql but I had to replace instances of `utf8mb` with `utf8` and `utf8mb4_0900_ai_ci` with `utf8_general_ci` in order to import the DB schema. I'm running: `mysql  Ver 15.1 Distrib 10.5.21-MariaDB, for debian-linux-gnu (x86_64) using  EditLine wrapper`
- Fix schema descriptions in root.rs which were referring to the wrong table (`user` => `product`)