### PR TITLE
Added trieve to example showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - [rustus](https://github.com/s3rius/rustus): A TUS protocol implementation that helps you handle file uploads
 - [gcs-proxy](https://github.com/guaychou/gcs-proxy): A Google Cloud Storage download proxy
 - [Actix-Web Shuttle Template](https://github.com/sentinel1909/shuttle-templat-actix): A somewhat opinionated template for getting started with an Actix Web API and hosting it on Shuttle.
+- [trieve](https://github.com/devflowinc/trieve): All-in-one infrastructure for building search, recommendations, and RAG.
 
 ## Community Articles, Example Apps, Starters & Boilerplate Projects
 


### PR DESCRIPTION
Added [trieve](https://github.com/devflowinc/trieve) to Actix examples/community showcase.