### PR TITLE
Fix chat-tcp panic when current directory is not the expected directory

### DIFF
--- a/websockets/chat-tcp/README.md
+++ b/websockets/chat-tcp/README.md
@@ -18,7 +18,14 @@ Chat server listens for incoming tcp connections. Server can access several type
 - `some message` - just string, send message to all peers in same room
 - client has to send heartbeat `Ping` messages, if server does not receive a heartbeat message for 10 seconds connection gets dropped
 
-To start server use command: `cargo run --bin websocket-tcp-server`
+To start server run
+
+```sh
+cd websockets/chat-tcp
+cargo run --bin websocket-tcp-server`
+```
+
+If the current directory is not correct, the server will look for `index.html` in the wrong place.
 
 ## Client
 


### PR DESCRIPTION
Prior to this change if you followed the websockets/chat-tcp README without first making your current directory websockets/chat-tcp, you would get a panic when you opened http://localhost:8080/ .

This uses `include_str!()` to include the index.html file at compile time referencing it relative to the source code file and avoids the use of the problematic `unwrap()` all together.