### PR TITLE
Simplify rustls usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,7 +2047,6 @@ dependencies = [
  "log",
  "notify 6.1.1",
  "rustls 0.23.25",
- "rustls-pemfile 2.2.0",
  "tokio",
 ]
 
@@ -5094,7 +5093,6 @@ dependencies = [
  "futures-util",
  "log",
  "rustls 0.23.25",
- "rustls-pemfile 2.2.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7006,7 +7006,6 @@ dependencies = [
  "env_logger",
  "log",
  "rustls 0.23.25",
- "rustls-pemfile 2.2.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6995,7 +6995,6 @@ dependencies = [
  "env_logger",
  "log",
  "rustls 0.23.25",
- "rustls-pemfile 2.2.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8410,7 +8410,6 @@ dependencies = [
  "eyre",
  "log",
  "rustls 0.23.25",
- "rustls-pemfile 2.2.0",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,6 @@ rand = "0.9"
 redis = { version = "0.27" }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 rustls = "0.23"
-rustls-pemfile = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 time = "0.3"

--- a/https-tls/acme-letsencrypt/Cargo.toml
+++ b/https-tls/acme-letsencrypt/Cargo.toml
@@ -12,5 +12,4 @@ env_logger.workspace = true
 eyre.workspace = true
 log.workspace = true
 rustls.workspace = true
-rustls-pemfile.workspace = true
 tokio = { workspace = true, features = ["fs"] }

--- a/https-tls/cert-watch/Cargo.toml
+++ b/https-tls/cert-watch/Cargo.toml
@@ -11,5 +11,4 @@ eyre.workspace = true
 log.workspace = true
 notify = "6"
 rustls.workspace = true
-rustls-pemfile.workspace = true
 tokio = { workspace = true, features = ["time", "rt", "macros"] }

--- a/https-tls/rustls-client-cert/Cargo.toml
+++ b/https-tls/rustls-client-cert/Cargo.toml
@@ -9,4 +9,3 @@ actix-web = { workspace = true, features = ["rustls-0_23"] }
 env_logger.workspace = true
 log.workspace = true
 rustls.workspace = true
-rustls-pemfile.workspace = true

--- a/https-tls/rustls/Cargo.toml
+++ b/https-tls/rustls/Cargo.toml
@@ -10,4 +10,3 @@ actix-files.workspace = true
 env_logger.workspace = true
 log.workspace = true
 rustls.workspace = true
-rustls-pemfile.workspace = true

--- a/https-tls/rustls/src/main.rs
+++ b/https-tls/rustls/src/main.rs
@@ -1,12 +1,12 @@
-use std::{fs::File, io::BufReader};
-
 use actix_files::Files;
 use actix_web::{
     App, HttpRequest, HttpResponse, HttpServer, http::header::ContentType, middleware, web,
 };
 use log::debug;
-use rustls::{ServerConfig, pki_types::PrivateKeyDer};
-use rustls_pemfile::{certs, pkcs8_private_keys};
+use rustls::{
+    ServerConfig,
+    pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject},
+};
 
 /// simple handle
 async fn index(req: HttpRequest) -> HttpResponse {
@@ -46,25 +46,17 @@ fn load_rustls_config() -> rustls::ServerConfig {
         .install_default()
         .unwrap();
 
-    // init server config builder with safe defaults
-    let config = ServerConfig::builder().with_no_client_auth();
-
     // load TLS key/cert files
-    let cert_file = &mut BufReader::new(File::open("cert.pem").unwrap());
-    let key_file = &mut BufReader::new(File::open("key.pem").unwrap());
+    let cert_chain = CertificateDer::pem_file_iter("cert.pem")
+        .unwrap()
+        .flatten()
+        .collect();
 
-    // convert files to key/cert objects
-    let cert_chain = certs(cert_file).collect::<Result<Vec<_>, _>>().unwrap();
-    let mut keys = pkcs8_private_keys(key_file)
-        .map(|key| key.map(PrivateKeyDer::Pkcs8))
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
+    let key_der =
+        PrivateKeyDer::from_pem_file("key.pem").expect("Could not locate PKCS 8 private keys.");
 
-    // exit if no keys could be parsed
-    if keys.is_empty() {
-        eprintln!("Could not locate PKCS 8 private keys.");
-        std::process::exit(1);
-    }
-
-    config.with_single_cert(cert_chain, keys.remove(0)).unwrap()
+    ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(cert_chain, key_der)
+        .unwrap()
 }

--- a/middleware/http-to-https/Cargo.toml
+++ b/middleware/http-to-https/Cargo.toml
@@ -9,4 +9,3 @@ env_logger.workspace = true
 futures-util.workspace = true
 log.workspace = true
 rustls.workspace = true
-rustls-pemfile.workspace = true


### PR DESCRIPTION
Usage of rustls-pemfile isn't necessary, rustls itself provides easier interface to load keys and certificates.

This looks a bit shorter and, hopefully, easier to read.