### PR TITLE
Fix typo in websockets\chat-tcp\README.md  #1121

### DIFF
--- a/websockets/chat-tcp/README.md
+++ b/websockets/chat-tcp/README.md
@@ -22,7 +22,7 @@ To start server run
 
 ```sh
 cd websockets/chat-tcp
-cargo run --bin websocket-tcp-server`
+cargo run --bin websocket-tcp-server
 ```
 
 If the current directory is not correct, the server will look for `index.html` in the wrong place.


### PR DESCRIPTION
Current command in README:
```
cargo run --bin websocket-tcp-server`
```
Now command:


```
cargo run --bin websocket-tcp-server
```
<img width="478" height="120" alt="Screenshot 2025-08-11 125631" src="https://github.com/user-attachments/assets/6d620c77-0076-47a7-a552-c46d9309a3f4" />