### PR TITLE
Fix typo extra `` 

### DIFF
--- a/auth/casbin/README.md
+++ b/auth/casbin/README.md
@@ -14,7 +14,7 @@ Modify the files in the `rbac` directory and the code in the `src` directory as 
 
 ```sh
 cd auth/casbin
-cargo run  # or: cargo watch -x run
+cargo run # or: cargo watch -x run
 
 # Started http server: 127.0.0.1:8080
 ```

--- a/auth/casbin/README.md
+++ b/auth/casbin/README.md
@@ -14,7 +14,7 @@ Modify the files in the `rbac` directory and the code in the `src` directory as 
 
 ```sh
 cd auth/casbin
-cargo run (or ``cargo watch -x run``)
+cargo run  # or: cargo watch -x run
 
 # Started http server: 127.0.0.1:8080
 ```

--- a/guards/README.md
+++ b/guards/README.md
@@ -22,7 +22,7 @@ Requires the `Accept-Version` header to be present and set to `1` or `2`.
 Using [HTTPie]:
 
 ```sh
-http :8080/api/hello Accept-Version:1
+http://localhost:8080/api/hello Accept-Version:1
 ```
 
 Using [cURL]:

--- a/guards/README.md
+++ b/guards/README.md
@@ -22,7 +22,7 @@ Requires the `Accept-Version` header to be present and set to `1` or `2`.
 Using [HTTPie]:
 
 ```sh
-http://localhost:8080/api/hello Accept-Version:1
+http :8080/api/hello Accept-Version:1
 ```
 
 Using [cURL]:


### PR DESCRIPTION
Older : 
<img width="926" height="167" alt="Screenshot 2025-08-11 142703" src="https://github.com/user-attachments/assets/b63c15a1-5c54-4cd5-a944-f4137df323f9" />

Now: 
<img width="513" height="129" alt="Screenshot 2025-08-11 142908" src="https://github.com/user-attachments/assets/9fddca0a-9288-4f6a-9af8-d9e66ee8b5e9" />

Result: 
<img width="724" height="178" alt="Screenshot 2025-08-11 142919" src="https://github.com/user-attachments/assets/ebdc0849-3954-4b6a-968f-4d002e6de6a3" />
