### PR TITLE
chore: drop shuttle-related stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@
 - [rustypaste](https://github.com/orhun/rustypaste): A minimal file upload/pastebin service
 - [rustus](https://github.com/s3rius/rustus): A TUS protocol implementation that helps you handle file uploads
 - [gcs-proxy](https://github.com/guaychou/gcs-proxy): A Google Cloud Storage download proxy
-- [Actix-Web Shuttle Template](https://github.com/sentinel1909/shuttle-templat-actix): A somewhat opinionated template for getting started with an Actix Web API and hosting it on Shuttle.
 - [trieve](https://github.com/devflowinc/trieve): All-in-one infrastructure for building search, recommendations, and RAG.
 - [openapi-rs](https://github.com/baerwang/openapi-rs/tree/main/examples/actix-web): This project adds a middleware layer to Actix Web using openapi-rs, enabling automatic request validation and processing based on OpenAPI 3.1 specifications. It helps ensure that the server behavior strictly follows the OpenAPI contract
 

--- a/auth/oauth-github/README.md
+++ b/auth/oauth-github/README.md
@@ -1,7 +1,0 @@
-# OAuth (GitHub)
-
-See <https://github.com/robjtede/actix-examples-oauth-github>.
-
-It is a sample app demonstrating GitHub OAuth login using Actix Web. It needs to live in it's own Git repo because Shuttle (the deployment service used) tries to deploy the whole examples repo if it were here.
-
-Live deployment test here: <https://actix-examples-oauth-github.shuttleapp.rs>.


### PR DESCRIPTION
ref. https://docs.shuttle.dev/docs/shuttle-shutdown
Also https://github.com/sentinel1909/shuttle-templat-actix is now 404.